### PR TITLE
Allow providing a custom `Interner` for tree building and to store one with the tree

### DIFF
--- a/examples/math.rs
+++ b/examples/math.rs
@@ -131,7 +131,7 @@ fn print(indent: usize, element: SyntaxElementRef<'_>, resolver: &impl Resolver)
             }
         }
 
-        NodeOrToken::Token(token) => println!("- {:?} {:?}", token.text(resolver), kind),
+        NodeOrToken::Token(token) => println!("- {:?} {:?}", token.resolve_text(resolver), kind),
     }
 }
 

--- a/examples/math.rs
+++ b/examples/math.rs
@@ -13,10 +13,7 @@
 //!     - "+" Token(Add)
 //!     - "4" Token(Number)
 
-use cstree::{
-    interning::{Reader, Resolver},
-    GreenNodeBuilder, NodeOrToken,
-};
+use cstree::{interning::Resolver, GreenNodeBuilder, NodeOrToken};
 use std::iter::Peekable;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -66,7 +63,7 @@ type SyntaxElement = cstree::NodeOrToken<SyntaxNode, SyntaxToken>;
 type SyntaxElementRef<'a> = cstree::NodeOrToken<&'a SyntaxNode, &'a SyntaxToken>;
 
 struct Parser<'input, I: Iterator<Item = (SyntaxKind, &'input str)>> {
-    builder: GreenNodeBuilder<'static>,
+    builder: GreenNodeBuilder<'static, 'static>,
     iter:    Peekable<I>,
 }
 impl<'input, I: Iterator<Item = (SyntaxKind, &'input str)>> Parser<'input, I> {

--- a/examples/s_expressions.rs
+++ b/examples/s_expressions.rs
@@ -62,10 +62,7 @@ impl cstree::Language for Lang {
 
 /// GreenNode is an immutable tree, which is cheap to change,
 /// but doesn't contain offsets and parent pointers.
-use cstree::{
-    interning::{Reader, Resolver},
-    GreenNode,
-};
+use cstree::{interning::Resolver, GreenNode};
 
 /// You can construct GreenNodes by hand, but a builder
 /// is helpful for top-down parsers: it maintains a stack
@@ -91,7 +88,7 @@ fn parse(text: &str) -> Parse<impl Resolver> {
         /// in *reverse* order.
         tokens:  Vec<(SyntaxKind, &'input str)>,
         /// the in-progress tree.
-        builder: GreenNodeBuilder<'static>,
+        builder: GreenNodeBuilder<'static, 'static>,
         /// the list of syntax errors we've accumulated
         /// so far.
         errors:  Vec<String>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ use std::fmt;
 pub use text_size::{TextLen, TextRange, TextSize};
 
 pub use crate::{
-    green::{Checkpoint, Children, GreenNode, GreenNodeBuilder, GreenToken, SyntaxKind},
+    green::{Checkpoint, Children, GreenNode, GreenNodeBuilder, GreenToken, NodeCache, SyntaxKind},
     syntax::{SyntaxElement, SyntaxElementChildren, SyntaxElementRef, SyntaxNode, SyntaxNodeChildren, SyntaxToken},
     syntax_text::SyntaxText,
     utility_types::{Direction, NodeOrToken, TokenAtOffset, WalkEvent},

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -1,6 +1,6 @@
 use std::{
     cell::UnsafeCell,
-    fmt::Write,
+    fmt::{self, Write},
     hash::{Hash, Hasher},
     iter, ptr,
     sync::atomic::{AtomicU32, Ordering},
@@ -872,6 +872,24 @@ where
     }
 }
 
+impl<L: Language, D, R> fmt::Debug for SyntaxNode<L, D, R>
+where
+    R: Resolver,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", Self::debug(self, self.resolver().as_ref(), f.alternate()))
+    }
+}
+
+impl<L: Language, D, R> fmt::Display for SyntaxNode<L, D, R>
+where
+    R: Resolver,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", Self::display(self, self.resolver().as_ref()))
+    }
+}
+
 impl<L: Language, D, R> SyntaxToken<L, D, R> {
     fn new(parent: &SyntaxNode<L, D, R>, index: u32, offset: TextSize) -> SyntaxToken<L, D, R> {
         Self {
@@ -997,6 +1015,24 @@ where
     #[inline]
     pub fn text(&self) -> &str {
         self.green().text(self.parent().resolver().as_ref())
+    }
+}
+
+impl<L: Language, D, R> fmt::Debug for SyntaxToken<L, D, R>
+where
+    R: Resolver,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", Self::debug(self, self.parent().resolver().as_ref()))
+    }
+}
+
+impl<L: Language, D, R> fmt::Display for SyntaxToken<L, D, R>
+where
+    R: Resolver,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", Self::display(self, self.parent().resolver().as_ref()))
     }
 }
 

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,8 +1,8 @@
 mod common;
 
 use common::TestLang;
-use cstree::{GreenNodeBuilder, SyntaxKind, SyntaxNode, TextRange};
-use lasso::Resolver;
+use cstree::{GreenNodeBuilder, NodeCache, SyntaxKind, SyntaxNode, TextRange};
+use lasso::{Interner, Resolver, Rodeo};
 
 #[derive(Debug)]
 enum Element<'s> {
@@ -26,7 +26,21 @@ fn build_tree<D>(root: &Element<'_>) -> (SyntaxNode<TestLang, D>, impl Resolver)
     (SyntaxNode::new_root(node), interner.unwrap())
 }
 
-fn build_recursive(root: &Element<'_>, builder: &mut GreenNodeBuilder, mut from: u16) -> u16 {
+fn build_tree_with_cache<'c, 'i, D, I>(root: &Element<'_>, cache: &'c mut NodeCache<'i, I>) -> SyntaxNode<TestLang, D>
+where
+    I: Interner,
+{
+    let mut builder = GreenNodeBuilder::with_cache(cache);
+    build_recursive(root, &mut builder, 0);
+    let (node, interner) = builder.finish();
+    assert!(interner.is_none());
+    SyntaxNode::new_root(node)
+}
+
+fn build_recursive<'c, 'i, I>(root: &Element<'_>, builder: &mut GreenNodeBuilder<'c, 'i, I>, mut from: u16) -> u16
+where
+    I: Interner,
+{
     match root {
         Element::Node(children) => {
             builder.start_node(SyntaxKind(from));
@@ -96,5 +110,32 @@ fn data() {
     {
         let node2 = tree.children().nth(2).unwrap();
         assert_eq!(node2.get_data(), None);
+    }
+}
+
+#[test]
+fn with_interner() {
+    let mut interner = Rodeo::new();
+    let mut cache = NodeCache::with_interner(&mut interner);
+    let tree = two_level_tree();
+    let tree = build_tree_with_cache::<(), _>(&tree, &mut cache);
+    let resolver = interner;
+
+    assert_eq!(tree.syntax_kind(), SyntaxKind(0));
+    assert_eq!(tree.kind(), SyntaxKind(0));
+    {
+        let leaf1_0 = tree.children().nth(1).unwrap().children_with_tokens().nth(0).unwrap();
+        let leaf1_0 = leaf1_0.into_token().unwrap();
+        assert_eq!(leaf1_0.syntax_kind(), SyntaxKind(5));
+        assert_eq!(leaf1_0.kind(), SyntaxKind(5));
+        assert_eq!(leaf1_0.text(&resolver), "1.0");
+        assert_eq!(leaf1_0.text_range(), TextRange::at(6.into(), 3.into()));
+    }
+    {
+        let node2 = tree.children().nth(2).unwrap();
+        assert_eq!(node2.syntax_kind(), SyntaxKind(6));
+        assert_eq!(node2.kind(), SyntaxKind(6));
+        assert_eq!(node2.children_with_tokens().count(), 3);
+        assert_eq!(node2.text(&resolver), "2.02.12.2");
     }
 }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,8 +1,10 @@
 mod common;
 
 use common::TestLang;
-use cstree::{GreenNodeBuilder, NodeCache, SyntaxKind, SyntaxNode, TextRange};
+use cstree::{GreenNode, GreenNodeBuilder, NodeCache, SyntaxKind, TextRange};
 use lasso::{Interner, Resolver, Rodeo};
+
+type SyntaxNode<D = (), R = ()> = cstree::SyntaxNode<TestLang, D, R>;
 
 #[derive(Debug)]
 enum Element<'s> {
@@ -19,14 +21,14 @@ fn two_level_tree() -> Element<'static> {
     ])
 }
 
-fn build_tree<D>(root: &Element<'_>) -> (SyntaxNode<TestLang, D>, impl Resolver) {
+fn build_tree<D>(root: &Element<'_>) -> (SyntaxNode<D>, impl Resolver) {
     let mut builder = GreenNodeBuilder::new();
     build_recursive(root, &mut builder, 0);
     let (node, interner) = builder.finish();
     (SyntaxNode::new_root(node), interner.unwrap())
 }
 
-fn build_tree_with_cache<'c, 'i, D, I>(root: &Element<'_>, cache: &'c mut NodeCache<'i, I>) -> SyntaxNode<TestLang, D>
+fn build_tree_with_cache<'c, 'i, I>(root: &Element<'_>, cache: &'c mut NodeCache<'i, I>) -> GreenNode
 where
     I: Interner,
 {
@@ -34,7 +36,7 @@ where
     build_recursive(root, &mut builder, 0);
     let (node, interner) = builder.finish();
     assert!(interner.is_none());
-    SyntaxNode::new_root(node)
+    node
 }
 
 fn build_recursive<'c, 'i, I>(root: &Element<'_>, builder: &mut GreenNodeBuilder<'c, 'i, I>, mut from: u16) -> u16
@@ -67,7 +69,7 @@ fn create() {
         let leaf1_0 = leaf1_0.into_token().unwrap();
         assert_eq!(leaf1_0.syntax_kind(), SyntaxKind(5));
         assert_eq!(leaf1_0.kind(), SyntaxKind(5));
-        assert_eq!(leaf1_0.text(&resolver), "1.0");
+        assert_eq!(leaf1_0.resolve_text(&resolver), "1.0");
         assert_eq!(leaf1_0.text_range(), TextRange::at(6.into(), 3.into()));
     }
     {
@@ -75,7 +77,7 @@ fn create() {
         assert_eq!(node2.syntax_kind(), SyntaxKind(6));
         assert_eq!(node2.kind(), SyntaxKind(6));
         assert_eq!(node2.children_with_tokens().count(), 3);
-        assert_eq!(node2.text(&resolver), "2.02.12.2");
+        assert_eq!(node2.resolve_text(&resolver), "2.02.12.2");
     }
 }
 
@@ -118,24 +120,38 @@ fn with_interner() {
     let mut interner = Rodeo::new();
     let mut cache = NodeCache::with_interner(&mut interner);
     let tree = two_level_tree();
-    let tree = build_tree_with_cache::<(), _>(&tree, &mut cache);
+    let tree = build_tree_with_cache(&tree, &mut cache);
+    let tree: SyntaxNode = SyntaxNode::new_root(tree);
     let resolver = interner;
-
-    assert_eq!(tree.syntax_kind(), SyntaxKind(0));
-    assert_eq!(tree.kind(), SyntaxKind(0));
     {
         let leaf1_0 = tree.children().nth(1).unwrap().children_with_tokens().nth(0).unwrap();
         let leaf1_0 = leaf1_0.into_token().unwrap();
-        assert_eq!(leaf1_0.syntax_kind(), SyntaxKind(5));
-        assert_eq!(leaf1_0.kind(), SyntaxKind(5));
-        assert_eq!(leaf1_0.text(&resolver), "1.0");
+        assert_eq!(leaf1_0.resolve_text(&resolver), "1.0");
         assert_eq!(leaf1_0.text_range(), TextRange::at(6.into(), 3.into()));
     }
     {
         let node2 = tree.children().nth(2).unwrap();
-        assert_eq!(node2.syntax_kind(), SyntaxKind(6));
-        assert_eq!(node2.kind(), SyntaxKind(6));
-        assert_eq!(node2.children_with_tokens().count(), 3);
-        assert_eq!(node2.text(&resolver), "2.02.12.2");
+        assert_eq!(node2.resolve_text(&resolver), "2.02.12.2");
+    }
+}
+
+#[test]
+fn inline_resolver() {
+    let mut interner = Rodeo::new();
+    let mut cache = NodeCache::with_interner(&mut interner);
+    let tree = two_level_tree();
+    let tree = build_tree_with_cache(&tree, &mut cache);
+    let tree: SyntaxNode<(), Rodeo> = SyntaxNode::new_root_with_resolver(tree, interner);
+    {
+        let leaf1_0 = tree.children().nth(1).unwrap().children_with_tokens().nth(0).unwrap();
+        let leaf1_0 = leaf1_0.into_token().unwrap();
+        assert_eq!(leaf1_0.text(), "1.0");
+        assert_eq!(leaf1_0.text_range(), TextRange::at(6.into(), 3.into()));
+    }
+    {
+        let node2 = tree.children().nth(2).unwrap();
+        assert_eq!(node2.text(), "2.02.12.2");
+        let resolver = node2.resolver();
+        assert_eq!(node2.resolve_text(resolver.as_ref()), node2.text());
     }
 }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -147,11 +147,23 @@ fn inline_resolver() {
         let leaf1_0 = leaf1_0.into_token().unwrap();
         assert_eq!(leaf1_0.text(), "1.0");
         assert_eq!(leaf1_0.text_range(), TextRange::at(6.into(), 3.into()));
+        assert_eq!(format!("{}", leaf1_0), leaf1_0.text());
+        assert_eq!(format!("{:?}", leaf1_0), "SyntaxKind(5)@6..9 \"1.0\"");
     }
     {
         let node2 = tree.children().nth(2).unwrap();
         assert_eq!(node2.text(), "2.02.12.2");
         let resolver = node2.resolver();
         assert_eq!(node2.resolve_text(resolver.as_ref()), node2.text());
+        assert_eq!(format!("{}", node2).as_str(), node2.text());
+        assert_eq!(format!("{:?}", node2), "SyntaxKind(6)@9..18");
+        assert_eq!(
+            format!("{:#?}", node2),
+            r#"SyntaxKind(6)@9..18
+  SyntaxKind(7)@9..12 "2.0"
+  SyntaxKind(8)@12..15 "2.1"
+  SyntaxKind(9)@15..18 "2.2"
+"#
+        );
     }
 }


### PR DESCRIPTION
`NodeCache` is given an additional `with_interner` method and now holds a `MaybeOwned<I>` (where `I: Interner`). It is made public, so it can be used with `GreenNodeBuilder::with_cache`. If `GreenNodeBuilder` is created with `new`, it constructs a default interner. It will always give back owned interners on `finish`.

For syntax nodes, `Kind::Root` now holds an additional `Arc` which can house a resolver. If a resolver is present, additional methods are offered to get `text` without the need to provide another resolver. Additionally, `Debug` and `Display` are implemented for `Syntax{Node, Token}` if their tree holds a resolver.
This adds another type parameter to all the `SyntaxXY`, which is starting to get a lot (see `SyntaxText` in particular). Hopefully, this was the last...

Closes #3 and adds some testing for #2.