### PR TITLE
Serializable trees

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,6 +250,7 @@ name = "servo_arc"
 version = "0.1.1"
 dependencies = [
  "nodrop",
+ "serde",
  "stable_deref_trait",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,18 +207,18 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.119"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bdd36f49e35b61d49efd8aa7fc068fd295961fd2286d0b2ee9a4c7a14e99cc3"
+checksum = "166b2349061381baf54a58e4b13c89369feb0ef2eaa57198899e2312aac30aab"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.119"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552954ce79a059ddd5fd68c271592374bd15cab2274970380c000118aeffe1cd"
+checksum = "0ca2a8cb5805ce9e3b95435e3765b7b553cecc762d938d409434338386cb5775"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -238,9 +238,9 @@ dependencies = [
 
 [[package]]
 name = "serde_test"
-version = "1.0.119"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60f3fb1454274c008f21e98e48780a4dde5347d4a728d873647be705405366ab"
+checksum = "3dd7d96489b14fa2f4a89be299ac117c8023d1ead9aaee963a2dde72dad4d14b"
 dependencies = [
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,9 +281,6 @@ name = "text-size"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "288cb548dbe72b652243ea797201f3d481a0609a967980fcc5b2315ea811560a"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "thread_local"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,8 @@ dependencies = [
  "m_lexer",
  "parking_lot",
  "serde",
+ "serde_json",
+ "serde_test",
  "servo_arc",
  "text-size",
 ]
@@ -66,6 +68,12 @@ checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "itoa"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "lasso"
@@ -144,6 +152,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+dependencies = [
+ "unicode-xid",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,6 +194,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
 
 [[package]]
+name = "ryu"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,6 +210,40 @@ name = "serde"
 version = "1.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bdd36f49e35b61d49efd8aa7fc068fd295961fd2286d0b2ee9a4c7a14e99cc3"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.119"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552954ce79a059ddd5fd68c271592374bd15cab2274970380c000118aeffe1cd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fceb2595057b6891a4ee808f70054bd2d12f0e97f1cbb78689b59f676df325a"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_test"
+version = "1.0.119"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60f3fb1454274c008f21e98e48780a4dde5347d4a728d873647be705405366ab"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "servo_arc"
@@ -200,6 +266,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "syn"
+version = "1.0.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc60a3d73ea6594cd712d830cc1f0390fd71542d8c8cd24e70cc54cdfd5e05d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "text-size"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -216,6 +293,12 @@ checksum = "bb9bc092d0d51e76b2b19d9d85534ffc9ec2db959a2523cdae0697e2972cd447"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,4 @@ serde_test = "1.0.119"
 
 [features]
 default = []
+serde1 = ["serde", "servo_arc/servo"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,15 +8,23 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/domenicquirl/cstree"
 
 [dependencies]
-serde = { version = "1.0.89", optional = true, default-features = false }
 lasso = "0.4.1"
 text-size = "1.0.0"
 fxhash= "0.2.1"
 servo_arc = { path = "vendor/servo_arc" }
 parking_lot= "0.11.1"
 
+[dependencies.serde]
+version = "1.0"
+optional = true
+default-features = false
+features = ["derive"]
+
 [dev-dependencies]
 m_lexer = "0.0.4"
+serde_json = "1.0.61"
+serde_test = "1.0.119"
 
 [features]
+default = ["serde1"]
 serde1 = ["serde", "text-size/serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,5 +26,5 @@ serde_json = "1.0.61"
 serde_test = "1.0.119"
 
 [features]
-default = ["serde1"]
+default = []
 serde1 = ["serde", "text-size/serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,3 @@ serde_test = "1.0.119"
 
 [features]
 default = []
-serde1 = ["serde", "text-size/serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,6 @@ serde_test = "1.0.119"
 [features]
 default = []
 serde1 = ["serde", "servo_arc/servo"]
+
+[package.metadata.docs.rs]
+features = ["serde1"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ mod green;
 #[allow(unsafe_code)]
 pub mod syntax;
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde1")]
 mod serde_impls;
 mod syntax_text;
 mod utility_types;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ mod green;
 #[allow(unsafe_code)]
 pub mod syntax;
 
-#[cfg(feature = "serde1")]
+#[cfg(feature = "serde")]
 mod serde_impls;
 mod syntax_text;
 mod utility_types;

--- a/src/serde_impls.rs
+++ b/src/serde_impls.rs
@@ -3,6 +3,7 @@
 use crate::{interning::Resolver, GreenNodeBuilder, Language, NodeOrToken, SyntaxKind, SyntaxNode, WalkEvent};
 use serde::{
     de::{SeqAccess, Visitor},
+    ser::SerializeTuple,
     Deserialize, Serialize,
 };
 use std::{fmt, marker::PhantomData};
@@ -12,7 +13,10 @@ type Rodeo = lasso::Rodeo<lasso::Spur, fxhash::FxBuildHasher>;
 #[derive(Deserialize, Serialize)]
 #[serde(tag = "t", content = "c")]
 enum Event<'text, L: Language> {
-    EnterNode(L::Kind),
+    /// The second parameter represents the data of the node.
+    /// `0` means there's no data, otherwise it's the `idx + 1`,
+    /// where `idx` is the element inside the data list.
+    EnterNode(L::Kind, u32),
     Token(L::Kind, &'text str),
     LeaveNode,
 }
@@ -21,21 +25,42 @@ impl<L, D, R> Serialize for SyntaxNode<L, D, R>
 where
     L: Language,
     <L as Language>::Kind: Serialize,
+    D: Serialize,
     R: Resolver,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
+        let mut counter = 0;
+        let mut data_list = Vec::new();
+
         let events = self.preorder_with_tokens().filter_map(|event| match event {
-            WalkEvent::Enter(NodeOrToken::Node(node)) => Some(Event::<L>::EnterNode(node.kind())),
+            WalkEvent::Enter(NodeOrToken::Node(node)) => {
+                let id = node
+                    .get_data()
+                    .map(|data| {
+                        data_list.push(data);
+                        counter += 1;
+                        counter
+                    })
+                    .unwrap_or(0);
+
+                Some(Event::<L>::EnterNode(node.kind(), id))
+            }
             WalkEvent::Enter(NodeOrToken::Token(tok)) => Some(Event::Token(tok.kind(), tok.text())),
 
             WalkEvent::Leave(NodeOrToken::Node(_)) => Some(Event::LeaveNode),
             WalkEvent::Leave(NodeOrToken::Token(_)) => None,
         });
 
-        serializer.collect_seq(events)
+        let mut tuple = serializer.serialize_tuple(2)?;
+
+        // TODO(Stupremee): We can easily avoid this allocation but it would
+        // require more weird and annoying-to-write code, so I'll skip it for now.
+        tuple.serialize_element(&events.collect::<Vec<_>>())?;
+        tuple.serialize_element(&data_list)?;
+        tuple.end()
     }
 }
 
@@ -43,6 +68,7 @@ impl<'de, L, D> Deserialize<'de> for SyntaxNode<L, D, Rodeo>
 where
     L: Language,
     <L as Language>::Kind: Deserialize<'de>,
+    D: Deserialize<'de>,
 {
     fn deserialize<DE>(deserializer: DE) -> Result<Self, DE::Error>
     where
@@ -56,8 +82,9 @@ where
         where
             L: Language,
             <L as Language>::Kind: Deserialize<'de>,
+            D: Deserialize<'de>,
         {
-            type Value = SyntaxNode<L, D, Rodeo>;
+            type Value = (SyntaxNode<L, D, Rodeo>, Vec<u32>);
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                 formatter.write_str("a list of tree events")
@@ -68,21 +95,55 @@ where
                 A: SeqAccess<'de>,
             {
                 let mut builder = GreenNodeBuilder::new();
+                let mut ids = Vec::new();
 
                 while let Some(next) = seq.next_element::<Event<'_, L>>()? {
                     match next {
-                        Event::EnterNode(kind) => builder.start_node(L::kind_to_raw(kind)),
+                        Event::EnterNode(kind, id) => {
+                            builder.start_node(L::kind_to_raw(kind));
+                            ids.push(id);
+                        }
                         Event::Token(kind, text) => builder.token(L::kind_to_raw(kind), text),
                         Event::LeaveNode => builder.finish_node(),
                     }
                 }
 
                 let (tree, resolver) = builder.finish();
-                Ok(SyntaxNode::new_root_with_resolver(tree, resolver.unwrap()))
+                let tree = SyntaxNode::new_root_with_resolver(tree, resolver.unwrap());
+                Ok((tree, ids))
             }
         }
 
-        deserializer.deserialize_seq(EventVisitor { _marker: PhantomData })
+        struct ProcessedEvents<L: Language, D: 'static>(SyntaxNode<L, D, Rodeo>, Vec<u32>);
+        impl<'de, L, D> Deserialize<'de> for ProcessedEvents<L, D>
+        where
+            L: Language,
+            <L as Language>::Kind: Deserialize<'de>,
+            D: Deserialize<'de>,
+        {
+            fn deserialize<DE>(deserializer: DE) -> Result<Self, DE::Error>
+            where
+                DE: serde::Deserializer<'de>,
+            {
+                let (tree, ids) = deserializer.deserialize_seq(EventVisitor { _marker: PhantomData })?;
+                Ok(Self(tree, ids))
+            }
+        }
+
+        let (ProcessedEvents(tree, ids), mut data) = <(ProcessedEvents<L, D>, Vec<D>)>::deserialize(deserializer)?;
+
+        let mut num_removed = 0;
+        tree.descendants().zip(ids).for_each(|(node, id)| {
+            if id == 0 {
+                return;
+            }
+
+            num_removed += 1;
+            let data = data.remove(id as usize - num_removed);
+            node.set_data(data);
+        });
+
+        Ok(tree)
     }
 }
 

--- a/src/serde_impls.rs
+++ b/src/serde_impls.rs
@@ -10,21 +10,84 @@ use std::{fmt, marker::PhantomData};
 
 type Rodeo = lasso::Rodeo<lasso::Spur, fxhash::FxBuildHasher>;
 
+macro_rules! data_list {
+    ($_:expr, $list:expr) => {
+        $list
+    };
+
+    ($list:expr,) => {
+        $list
+    };
+}
+
+macro_rules! gen_serialize {
+    ($l:ident, $node:expr, $ser:ident, $counter:ident, $($data_list:ident)?) => {{
+        #[allow(unused_variables)]
+        let events = $node.preorder_with_tokens().filter_map(|event| match event {
+            WalkEvent::Enter(NodeOrToken::Node(node)) => {
+                let id = 0;
+                $(let id = node
+                    .get_data()
+                    .map(|data| {
+                        $data_list.push(data);
+                        $counter += 1;
+                        $counter
+                    })
+                    .unwrap_or(0);)?
+
+                Some(Event::EnterNode($l::kind_to_raw(node.kind()), id))
+            }
+            WalkEvent::Enter(NodeOrToken::Token(tok)) => Some(Event::Token($l::kind_to_raw(tok.kind()), tok.text())),
+
+            WalkEvent::Leave(NodeOrToken::Node(_)) => Some(Event::LeaveNode),
+            WalkEvent::Leave(NodeOrToken::Token(_)) => None,
+        });
+
+        let mut tuple = $ser.serialize_tuple(2)?;
+
+        // TODO(Stupremee): We can easily avoid this allocation but it would
+        // require more weird and annoying-to-write code, so I'll skip it for now.
+        tuple.serialize_element(&events.collect::<Vec<_>>())?;
+
+        tuple.serialize_element(&data_list!(Vec::<()>::new(), $($data_list)?))?;
+
+        tuple.end()
+    }};
+}
+
 #[derive(Deserialize, Serialize)]
 #[serde(tag = "t", content = "c")]
-enum Event<'text, L: Language> {
+enum Event<'text> {
     /// The second parameter represents the data of the node.
     /// `0` means there's no data, otherwise it's the `idx + 1`,
     /// where `idx` is the element inside the data list.
-    EnterNode(L::Kind, u32),
-    Token(L::Kind, &'text str),
+    EnterNode(SyntaxKind, u32),
+    Token(SyntaxKind, &'text str),
     LeaveNode,
+}
+
+/// Make a `SyntaxNode` serializable, even if it doesn't have
+/// data that is serializable.
+pub(crate) struct SerializeWithoutData<'node, L: Language, D: 'static, R: 'static> {
+    pub(crate) node: &'node SyntaxNode<L, D, R>,
+}
+
+impl<L, D, R> Serialize for SerializeWithoutData<'_, L, D, R>
+where
+    L: Language,
+    R: Resolver,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        gen_serialize!(L, self.node, serializer, __,)
+    }
 }
 
 impl<L, D, R> Serialize for SyntaxNode<L, D, R>
 where
     L: Language,
-    <L as Language>::Kind: Serialize,
     D: Serialize,
     R: Resolver,
 {
@@ -34,40 +97,13 @@ where
     {
         let mut counter = 0;
         let mut data_list = Vec::new();
-
-        let events = self.preorder_with_tokens().filter_map(|event| match event {
-            WalkEvent::Enter(NodeOrToken::Node(node)) => {
-                let id = node
-                    .get_data()
-                    .map(|data| {
-                        data_list.push(data);
-                        counter += 1;
-                        counter
-                    })
-                    .unwrap_or(0);
-
-                Some(Event::<L>::EnterNode(node.kind(), id))
-            }
-            WalkEvent::Enter(NodeOrToken::Token(tok)) => Some(Event::Token(tok.kind(), tok.text())),
-
-            WalkEvent::Leave(NodeOrToken::Node(_)) => Some(Event::LeaveNode),
-            WalkEvent::Leave(NodeOrToken::Token(_)) => None,
-        });
-
-        let mut tuple = serializer.serialize_tuple(2)?;
-
-        // TODO(Stupremee): We can easily avoid this allocation but it would
-        // require more weird and annoying-to-write code, so I'll skip it for now.
-        tuple.serialize_element(&events.collect::<Vec<_>>())?;
-        tuple.serialize_element(&data_list)?;
-        tuple.end()
+        gen_serialize!(L, self, serializer, counter, data_list)
     }
 }
 
 impl<'de, L, D> Deserialize<'de> for SyntaxNode<L, D, Rodeo>
 where
     L: Language,
-    <L as Language>::Kind: Deserialize<'de>,
     D: Deserialize<'de>,
 {
     fn deserialize<DE>(deserializer: DE) -> Result<Self, DE::Error>
@@ -81,7 +117,6 @@ where
         impl<'de, L, D> Visitor<'de> for EventVisitor<L, D>
         where
             L: Language,
-            <L as Language>::Kind: Deserialize<'de>,
             D: Deserialize<'de>,
         {
             type Value = (SyntaxNode<L, D, Rodeo>, Vec<u32>);
@@ -97,13 +132,13 @@ where
                 let mut builder = GreenNodeBuilder::new();
                 let mut ids = Vec::new();
 
-                while let Some(next) = seq.next_element::<Event<'_, L>>()? {
+                while let Some(next) = seq.next_element::<Event<'_>>()? {
                     match next {
                         Event::EnterNode(kind, id) => {
-                            builder.start_node(L::kind_to_raw(kind));
+                            builder.start_node(kind);
                             ids.push(id);
                         }
-                        Event::Token(kind, text) => builder.token(L::kind_to_raw(kind), text),
+                        Event::Token(kind, text) => builder.token(kind, text),
                         Event::LeaveNode => builder.finish_node(),
                     }
                 }
@@ -118,7 +153,6 @@ where
         impl<'de, L, D> Deserialize<'de> for ProcessedEvents<L, D>
         where
             L: Language,
-            <L as Language>::Kind: Deserialize<'de>,
             D: Deserialize<'de>,
         {
             fn deserialize<DE>(deserializer: DE) -> Result<Self, DE::Error>

--- a/src/serde_impls.rs
+++ b/src/serde_impls.rs
@@ -1,63 +1,105 @@
-use serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};
-use std::fmt;
+//! Serialization and Deserialization for syntax trees.
 
-use crate::{Language, NodeOrToken, SyntaxNode, SyntaxToken};
+use crate::{interning::Resolver, GreenNodeBuilder, Language, NodeOrToken, SyntaxKind, SyntaxNode, WalkEvent};
+use serde::{
+    de::{SeqAccess, Visitor},
+    Deserialize, Serialize,
+};
+use std::{fmt, marker::PhantomData};
 
-struct SerDisplay<T>(T);
-impl<T: fmt::Display> Serialize for SerDisplay<T> {
+type Rodeo = lasso::Rodeo<lasso::Spur, fxhash::FxBuildHasher>;
+
+#[derive(Deserialize, Serialize)]
+#[serde(tag = "t", content = "c")]
+enum Event<'text, L: Language> {
+    EnterNode(L::Kind),
+    Token(L::Kind, &'text str),
+    LeaveNode,
+}
+
+impl<L, D, R> Serialize for SyntaxNode<L, D, R>
+where
+    L: Language,
+    <L as Language>::Kind: Serialize,
+    R: Resolver,
+{
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: Serializer,
+        S: serde::Serializer,
     {
-        serializer.collect_str(&self.0)
+        let events = self.preorder_with_tokens().filter_map(|event| match event {
+            WalkEvent::Enter(NodeOrToken::Node(node)) => Some(Event::<L>::EnterNode(node.kind())),
+            WalkEvent::Enter(NodeOrToken::Token(tok)) => Some(Event::Token(tok.kind(), tok.text())),
+
+            WalkEvent::Leave(NodeOrToken::Node(_)) => Some(Event::LeaveNode),
+            WalkEvent::Leave(NodeOrToken::Token(_)) => None,
+        });
+
+        serializer.collect_seq(events)
     }
 }
 
-struct DisplayDebug<T>(T);
-impl<T: fmt::Debug> fmt::Display for DisplayDebug<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(&self.0, f)
+impl<'de, L, D> Deserialize<'de> for SyntaxNode<L, D, Rodeo>
+where
+    L: Language,
+    <L as Language>::Kind: Deserialize<'de>,
+{
+    fn deserialize<DE>(deserializer: DE) -> Result<Self, DE::Error>
+    where
+        DE: serde::Deserializer<'de>,
+    {
+        struct EventVisitor<L: Language, D: 'static> {
+            _marker: PhantomData<SyntaxNode<L, D, Rodeo>>,
+        }
+
+        impl<'de, L, D> Visitor<'de> for EventVisitor<L, D>
+        where
+            L: Language,
+            <L as Language>::Kind: Deserialize<'de>,
+        {
+            type Value = SyntaxNode<L, D, Rodeo>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a list of tree events")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let mut builder = GreenNodeBuilder::new();
+
+                while let Some(next) = seq.next_element::<Event<'_, L>>()? {
+                    match next {
+                        Event::EnterNode(kind) => builder.start_node(L::kind_to_raw(kind)),
+                        Event::Token(kind, text) => builder.token(L::kind_to_raw(kind), text),
+                        Event::LeaveNode => builder.finish_node(),
+                    }
+                }
+
+                let (tree, resolver) = builder.finish();
+                Ok(SyntaxNode::new_root_with_resolver(tree, resolver.unwrap()))
+            }
+        }
+
+        deserializer.deserialize_seq(EventVisitor { _marker: PhantomData })
     }
 }
 
-impl<L: Language> Serialize for SyntaxNode<L> {
+impl Serialize for SyntaxKind {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: Serializer,
+        S: serde::Serializer,
     {
-        let mut state = serializer.serialize_map(Some(3))?;
-        state.serialize_entry("kind", &SerDisplay(DisplayDebug(self.kind())))?;
-        state.serialize_entry("text_range", &self.text_range())?;
-        state.serialize_entry("children", &Children(self))?;
-        state.end()
+        serializer.serialize_u16(self.0)
     }
 }
 
-impl<L: Language> Serialize for SyntaxToken<L> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+impl<'de> Deserialize<'de> for SyntaxKind {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        S: Serializer,
+        D: serde::Deserializer<'de>,
     {
-        let mut state = serializer.serialize_map(Some(3))?;
-        state.serialize_entry("kind", &SerDisplay(DisplayDebug(self.kind())))?;
-        state.serialize_entry("text_range", &self.text_range())?;
-        state.serialize_entry("text", &self.text().as_str())?;
-        state.end()
-    }
-}
-
-struct Children<T>(T);
-
-impl<L: Language> Serialize for Children<&'_ SyntaxNode<L>> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut state = serializer.serialize_seq(None)?;
-        self.0.children_with_tokens().try_for_each(|element| match element {
-            NodeOrToken::Node(it) => state.serialize_element(&it),
-            NodeOrToken::Token(it) => state.serialize_element(&it),
-        })?;
-        state.end()
+        Ok(Self(u16::deserialize(deserializer)?))
     }
 }

--- a/src/serde_impls.rs
+++ b/src/serde_impls.rs
@@ -226,7 +226,7 @@ where
                 node.set_data(data);
             }
             <Result<(), DE::Error>>::Ok(())
-        });
+        })?;
 
         Ok(tree)
     }

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -909,10 +909,7 @@ where
     pub fn as_serialize_with_resolver<'node>(
         &'node self,
         resolver: &'node impl Resolver,
-    ) -> impl serde::Serialize + 'node
-    where
-        D: serde::Serialize,
-    {
+    ) -> impl serde::Serialize + 'node {
         SerializeWithResolver { node: self, resolver }
     }
 }

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -6,6 +6,8 @@ use std::{
     sync::atomic::{AtomicU32, Ordering},
 };
 
+#[cfg(feature = "serde1")]
+use crate::serde_impls::{SerializeWithData, SerializeWithResolver};
 use parking_lot::RwLock;
 use servo_arc::Arc;
 
@@ -879,12 +881,12 @@ where
 {
     /// Return an anonymous object that can be used to serialize this node,
     /// including the data for each node.
-    pub fn serialize_with_data(&self) -> impl serde::Serialize + '_
+    pub fn as_serialize_with_data(&self) -> impl serde::Serialize + '_
     where
         R: Resolver,
         D: serde::Serialize,
     {
-        crate::serde_impls::SerializeWithData {
+        SerializeWithData {
             node:     self,
             resolver: self.resolver().as_ref(),
         }
@@ -892,23 +894,26 @@ where
 
     /// Return an anonymous object that can be used to serialize this node,
     /// including the data and by using an external resolver.
-    pub fn serialize_with_data_with_resolver<'node>(
+    pub fn as_serialize_with_data_with_resolver<'node>(
         &'node self,
         resolver: &'node impl Resolver,
     ) -> impl serde::Serialize + 'node
     where
         D: serde::Serialize,
     {
-        crate::serde_impls::SerializeWithData { node: self, resolver }
+        SerializeWithData { node: self, resolver }
     }
 
     /// Return an anonymous object that can be used to serialize this node,
     /// which uses the given resolver instead of the resolver inside the tree.
-    pub fn serialize_with_resolver<'node>(&'node self, resolver: &'node impl Resolver) -> impl serde::Serialize + 'node
+    pub fn as_serialize_with_resolver<'node>(
+        &'node self,
+        resolver: &'node impl Resolver,
+    ) -> impl serde::Serialize + 'node
     where
         D: serde::Serialize,
     {
-        crate::serde_impls::SerializeWithResolver { node: self, resolver }
+        SerializeWithResolver { node: self, resolver }
     }
 }
 

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -873,14 +873,38 @@ where
 }
 
 #[cfg(feature = "serde1")]
-impl<L: Language, D, R: Resolver> SyntaxNode<L, D, R>
+impl<L, D, R> SyntaxNode<L, D, R>
 where
     L: Language,
 {
     /// Return an anonymous object that can be used to serialize this node,
     /// without serializing the data.
-    pub fn serialize_without_data(&self) -> impl serde::Serialize + '_ {
-        crate::serde_impls::SerializeWithoutData { node: self }
+    pub fn serialize_without_data(&self) -> impl serde::Serialize + '_
+    where
+        R: Resolver,
+    {
+        crate::serde_impls::SerializeWithoutData {
+            node:     self,
+            resolver: self.resolver().as_ref(),
+        }
+    }
+
+    /// Return an anonymous object that can be used to serialize this node,
+    /// without serializing the data.
+    pub fn serialize_without_data_with_resolver<'node>(
+        &'node self,
+        resolver: &'node impl Resolver,
+    ) -> impl serde::Serialize + 'node {
+        crate::serde_impls::SerializeWithoutData { node: self, resolver }
+    }
+
+    /// Return an anonymous object that can be used to serialize this node,
+    /// which uses the given resolver instead of the resolver inside the tree.
+    pub fn serialize_with_resolver<'node>(&'node self, resolver: &'node impl Resolver) -> impl serde::Serialize + 'node
+    where
+        D: serde::Serialize,
+    {
+        crate::serde_impls::SerializeWithResolver { node: self, resolver }
     }
 }
 

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -872,6 +872,18 @@ where
     }
 }
 
+#[cfg(feature = "serde1")]
+impl<L: Language, D, R: Resolver> SyntaxNode<L, D, R>
+where
+    L: Language,
+{
+    /// Return an anonymous object that can be used to serialize this node,
+    /// without serializing the data.
+    pub fn serialize_without_data(&self) -> impl serde::Serialize + '_ {
+        crate::serde_impls::SerializeWithoutData { node: self }
+    }
+}
+
 impl<L: Language, D, R> fmt::Debug for SyntaxNode<L, D, R>
 where
     R: Resolver,

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -878,24 +878,28 @@ where
     L: Language,
 {
     /// Return an anonymous object that can be used to serialize this node,
-    /// without serializing the data.
-    pub fn serialize_without_data(&self) -> impl serde::Serialize + '_
+    /// including the data for each node.
+    pub fn serialize_with_data(&self) -> impl serde::Serialize + '_
     where
         R: Resolver,
+        D: serde::Serialize,
     {
-        crate::serde_impls::SerializeWithoutData {
+        crate::serde_impls::SerializeWithData {
             node:     self,
             resolver: self.resolver().as_ref(),
         }
     }
 
     /// Return an anonymous object that can be used to serialize this node,
-    /// without serializing the data.
-    pub fn serialize_without_data_with_resolver<'node>(
+    /// including the data and by using an external resolver.
+    pub fn serialize_with_data_with_resolver<'node>(
         &'node self,
         resolver: &'node impl Resolver,
-    ) -> impl serde::Serialize + 'node {
-        crate::serde_impls::SerializeWithoutData { node: self, resolver }
+    ) -> impl serde::Serialize + 'node
+    where
+        D: serde::Serialize,
+    {
+        crate::serde_impls::SerializeWithData { node: self, resolver }
     }
 
     /// Return an anonymous object that can be used to serialize this node,

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,8 +1,24 @@
 mod common;
 
-use common::{build_tree, build_tree_with_cache, two_level_tree, SyntaxNode};
-use cstree::{NodeCache, SyntaxKind, TextRange};
-use lasso::Rodeo;
+use common::{build_recursive, build_tree_with_cache, Element, SyntaxNode};
+use cstree::{GreenNodeBuilder, NodeCache, SyntaxKind, TextRange};
+use lasso::{Resolver, Rodeo};
+
+fn build_tree<D>(root: &Element<'_>) -> (SyntaxNode<D>, impl Resolver) {
+    let mut builder = GreenNodeBuilder::new();
+    build_recursive(root, &mut builder, 0);
+    let (node, interner) = builder.finish();
+    (SyntaxNode::new_root(node), interner.unwrap())
+}
+
+fn two_level_tree() -> Element<'static> {
+    use Element::*;
+    Node(vec![
+        Node(vec![Token("0.0"), Token("0.1")]),
+        Node(vec![Token("1.0")]),
+        Node(vec![Token("2.0"), Token("2.1"), Token("2.2")]),
+    ])
+}
 
 #[test]
 fn create() {

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,62 +1,8 @@
 mod common;
 
-use common::TestLang;
-use cstree::{GreenNode, GreenNodeBuilder, NodeCache, SyntaxKind, TextRange};
-use lasso::{Interner, Resolver, Rodeo};
-
-type SyntaxNode<D = (), R = ()> = cstree::SyntaxNode<TestLang, D, R>;
-
-#[derive(Debug)]
-enum Element<'s> {
-    Node(Vec<Element<'s>>),
-    Token(&'s str),
-}
-
-fn two_level_tree() -> Element<'static> {
-    use Element::*;
-    Node(vec![
-        Node(vec![Token("0.0"), Token("0.1")]),
-        Node(vec![Token("1.0")]),
-        Node(vec![Token("2.0"), Token("2.1"), Token("2.2")]),
-    ])
-}
-
-fn build_tree<D>(root: &Element<'_>) -> (SyntaxNode<D>, impl Resolver) {
-    let mut builder = GreenNodeBuilder::new();
-    build_recursive(root, &mut builder, 0);
-    let (node, interner) = builder.finish();
-    (SyntaxNode::new_root(node), interner.unwrap())
-}
-
-fn build_tree_with_cache<'c, 'i, I>(root: &Element<'_>, cache: &'c mut NodeCache<'i, I>) -> GreenNode
-where
-    I: Interner,
-{
-    let mut builder = GreenNodeBuilder::with_cache(cache);
-    build_recursive(root, &mut builder, 0);
-    let (node, interner) = builder.finish();
-    assert!(interner.is_none());
-    node
-}
-
-fn build_recursive<'c, 'i, I>(root: &Element<'_>, builder: &mut GreenNodeBuilder<'c, 'i, I>, mut from: u16) -> u16
-where
-    I: Interner,
-{
-    match root {
-        Element::Node(children) => {
-            builder.start_node(SyntaxKind(from));
-            for child in children {
-                from = build_recursive(child, builder, from + 1);
-            }
-            builder.finish_node();
-        }
-        Element::Token(text) => {
-            builder.token(SyntaxKind(from), *text);
-        }
-    }
-    from
-}
+use common::{build_tree, build_tree_with_cache, two_level_tree, SyntaxNode};
+use cstree::{NodeCache, SyntaxKind, TextRange};
+use lasso::Rodeo;
 
 #[test]
 fn create() {

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,4 +1,11 @@
-use cstree::{Language, SyntaxKind};
+#![allow(unused)]
+
+use cstree::{
+    interning::{Interner, Resolver},
+    GreenNode, GreenNodeBuilder, Language, NodeCache, SyntaxKind,
+};
+
+pub type SyntaxNode<D = (), R = ()> = cstree::SyntaxNode<TestLang, D, R>;
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum TestLang {}
@@ -12,4 +19,65 @@ impl Language for TestLang {
     fn kind_to_raw(kind: Self::Kind) -> SyntaxKind {
         kind
     }
+}
+
+#[derive(Debug)]
+pub enum Element<'s> {
+    Node(Vec<Element<'s>>),
+    Token(&'s str),
+}
+
+pub fn two_level_tree() -> Element<'static> {
+    use Element::*;
+    Node(vec![
+        Node(vec![Token("0.0"), Token("0.1")]),
+        Node(vec![Token("1.0")]),
+        Node(vec![Token("2.0"), Token("2.1"), Token("2.2")]),
+    ])
+}
+
+pub fn big_tree() -> Element<'static> {
+    use Element::*;
+
+    Node(vec![
+        Node(vec![Node(vec![Token("foo"), Token("bar")]), Token("baz")]),
+        Node(vec![Token("pub"), Token("fn"), Token("tree")]),
+    ])
+}
+
+pub fn build_tree<D>(root: &Element<'_>) -> (SyntaxNode<D>, impl Resolver) {
+    let mut builder = GreenNodeBuilder::new();
+    build_recursive(root, &mut builder, 0);
+    let (node, interner) = builder.finish();
+    (SyntaxNode::new_root(node), interner.unwrap())
+}
+
+pub fn build_tree_with_cache<'c, 'i, I>(root: &Element<'_>, cache: &'c mut NodeCache<'i, I>) -> GreenNode
+where
+    I: Interner,
+{
+    let mut builder = GreenNodeBuilder::with_cache(cache);
+    build_recursive(root, &mut builder, 0);
+    let (node, interner) = builder.finish();
+    assert!(interner.is_none());
+    node
+}
+
+pub fn build_recursive<'c, 'i, I>(root: &Element<'_>, builder: &mut GreenNodeBuilder<'c, 'i, I>, mut from: u16) -> u16
+where
+    I: Interner,
+{
+    match root {
+        Element::Node(children) => {
+            builder.start_node(SyntaxKind(from));
+            for child in children {
+                from = build_recursive(child, builder, from + 1);
+            }
+            builder.finish_node();
+        }
+        Element::Token(text) => {
+            builder.token(SyntaxKind(from), *text);
+        }
+    }
+    from
 }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,9 +1,13 @@
-use cstree::{
-    interning::{Interner, Resolver},
-    GreenNode, GreenNodeBuilder, Language, NodeCache, SyntaxKind,
-};
+use cstree::{GreenNode, GreenNodeBuilder, Language, NodeCache, SyntaxKind};
+use lasso::Interner;
 
 pub type SyntaxNode<D = (), R = ()> = cstree::SyntaxNode<TestLang, D, R>;
+
+#[derive(Debug)]
+pub enum Element<'s> {
+    Node(Vec<Element<'s>>),
+    Token(&'s str),
+}
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum TestLang {}
@@ -17,37 +21,6 @@ impl Language for TestLang {
     fn kind_to_raw(kind: Self::Kind) -> SyntaxKind {
         kind
     }
-}
-
-#[derive(Debug)]
-pub enum Element<'s> {
-    Node(Vec<Element<'s>>),
-    Token(&'s str),
-}
-
-pub fn two_level_tree() -> Element<'static> {
-    use Element::*;
-    Node(vec![
-        Node(vec![Token("0.0"), Token("0.1")]),
-        Node(vec![Token("1.0")]),
-        Node(vec![Token("2.0"), Token("2.1"), Token("2.2")]),
-    ])
-}
-
-pub fn big_tree() -> Element<'static> {
-    use Element::*;
-
-    Node(vec![
-        Node(vec![Node(vec![Token("foo"), Token("bar")]), Token("baz")]),
-        Node(vec![Token("pub"), Token("fn"), Token("tree")]),
-    ])
-}
-
-pub fn build_tree<D>(root: &Element<'_>) -> (SyntaxNode<D>, impl Resolver) {
-    let mut builder = GreenNodeBuilder::new();
-    build_recursive(root, &mut builder, 0);
-    let (node, interner) = builder.finish();
-    (SyntaxNode::new_root(node), interner.unwrap())
 }
 
 pub fn build_tree_with_cache<'c, 'i, I>(root: &Element<'_>, cache: &'c mut NodeCache<'i, I>) -> GreenNode

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,5 +1,3 @@
-#![allow(unused)]
-
 use cstree::{
     interning::{Interner, Resolver},
     GreenNode, GreenNodeBuilder, Language, NodeCache, SyntaxKind,

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -74,7 +74,7 @@ impl PartialEq<TestNode> for TestNode {
 fn serialize_data_tree() {
     let tree = TestNode(build_tree_with_data());
 
-    let serialized = serde_json::to_string_pretty(&tree).unwrap();
+    let serialized = serde_json::to_string_pretty(&tree.0.serialize_with_data()).unwrap();
     let deserialized = serde_json::from_str::<TestNode>(&serialized).unwrap();
     assert_eq!(tree, deserialized);
 }
@@ -83,7 +83,7 @@ fn serialize_data_tree() {
 fn serialize_data_tree_without_data() {
     let tree = TestNode(build_tree_with_data());
 
-    let serialized = serde_json::to_string_pretty(&tree.0.serialize_without_data()).unwrap();
+    let serialized = serde_json::to_string_pretty(&tree.0).unwrap();
     let deserialized = serde_json::from_str::<TestNode>(&serialized).unwrap();
 
     tree.0.descendants().for_each(|node| node.clear_data());

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,0 +1,168 @@
+mod common;
+
+use common::TestLang;
+use cstree::{GreenNodeBuilder, SyntaxNode};
+use serde_test::{assert_tokens, Token::*};
+
+type Rodeo = lasso::Rodeo<lasso::Spur, fxhash::FxBuildHasher>;
+
+fn build_tree() -> SyntaxNode<TestLang, (), Rodeo> {
+    let tree = common::big_tree();
+    let mut builder = GreenNodeBuilder::new();
+    common::build_recursive(&tree, &mut builder, 0);
+    let (node, interner) = builder.finish();
+
+    SyntaxNode::<TestLang, (), _>::new_root_with_resolver(node, interner.unwrap())
+}
+
+/// Serializable SyntaxNode that doesn't have a identity `PartialEq` implementation.
+#[derive(Debug)]
+struct TestNode(SyntaxNode<TestLang, (), Rodeo>);
+
+impl serde::Serialize for TestNode {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for TestNode {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(Self(SyntaxNode::deserialize(deserializer)?))
+    }
+}
+
+impl PartialEq<TestNode> for TestNode {
+    fn eq(&self, other: &TestNode) -> bool {
+        self.0.kind() == other.0.kind() && self.0.text_range() == other.0.text_range()
+    }
+}
+
+#[test]
+fn serialize_big_tree() {
+    let tree = TestNode(build_tree());
+    print!("{}", serde_json::to_string_pretty(&tree).unwrap());
+
+    #[rustfmt::skip]
+    assert_tokens(
+        &tree,
+        &[
+            Seq { len: Option::None },
+
+            Struct { name: "Event", len: 2 },
+            BorrowedStr("t"),
+            BorrowedStr("EnterNode"),
+            BorrowedStr("c"),
+            U16(0),
+            StructEnd,
+
+            Struct { name: "Event", len: 2 },
+            BorrowedStr("t"),
+            BorrowedStr("EnterNode"),
+            BorrowedStr("c"),
+            U16(1),
+            StructEnd,
+
+            Struct { name: "Event", len: 2 },
+            BorrowedStr("t"),
+            BorrowedStr("EnterNode"),
+            BorrowedStr("c"),
+            U16(2),
+            StructEnd,
+
+            Struct { name: "Event", len: 2 },
+            BorrowedStr("t"),
+            BorrowedStr("Token"),
+            BorrowedStr("c"),
+            Tuple { len: 2 },
+            U16(3),
+            BorrowedStr("foo"),
+            TupleEnd,
+            StructEnd,
+
+            Struct { name: "Event", len: 2 },
+            BorrowedStr("t"),
+            BorrowedStr("Token"),
+            BorrowedStr("c"),
+            Tuple { len: 2 },
+            U16(4),
+            BorrowedStr("bar"),
+            TupleEnd,
+            StructEnd,
+
+            Struct { name: "Event", len: 1 },
+            BorrowedStr("t"),
+            BorrowedStr("LeaveNode"),
+            StructEnd,
+
+            Struct { name: "Event", len: 2 },
+            BorrowedStr("t"),
+            BorrowedStr("Token"),
+            BorrowedStr("c"),
+            Tuple { len: 2 },
+            U16(5),
+            BorrowedStr("baz"),
+            TupleEnd,
+            StructEnd,
+
+            Struct { name: "Event", len: 1 },
+            BorrowedStr("t"),
+            BorrowedStr("LeaveNode"),
+            StructEnd,
+
+            Struct { name: "Event", len: 2 },
+            BorrowedStr("t"),
+            BorrowedStr("EnterNode"),
+            BorrowedStr("c"),
+            U16(6),
+            StructEnd,
+
+            Struct { name: "Event", len: 2 },
+            BorrowedStr("t"),
+            BorrowedStr("Token"),
+            BorrowedStr("c"),
+            Tuple { len: 2 },
+            U16(7),
+            BorrowedStr("pub"),
+            TupleEnd,
+            StructEnd,
+
+            Struct { name: "Event", len: 2 },
+            BorrowedStr("t"),
+            BorrowedStr("Token"),
+            BorrowedStr("c"),
+            Tuple { len: 2 },
+            U16(8),
+            BorrowedStr("fn"),
+            TupleEnd,
+            StructEnd,
+
+            Struct { name: "Event", len: 2 },
+            BorrowedStr("t"),
+            BorrowedStr("Token"),
+            BorrowedStr("c"),
+            Tuple { len: 2 },
+            U16(9),
+            BorrowedStr("tree"),
+            TupleEnd,
+            StructEnd,
+
+            Struct { name: "Event", len: 1 },
+            BorrowedStr("t"),
+            BorrowedStr("LeaveNode"),
+            StructEnd,
+
+            Struct { name: "Event", len: 1 },
+            BorrowedStr("t"),
+            BorrowedStr("LeaveNode"),
+            StructEnd,
+
+            SeqEnd,
+        ],
+    );
+}

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -109,7 +109,7 @@ fn serialize_big_tree() {
             BorrowedStr("c"),
             Tuple { len: 2 },
             U16(0),
-            U32(0),
+            Bool(false),
             TupleEnd,
             StructEnd,
 
@@ -119,7 +119,7 @@ fn serialize_big_tree() {
             BorrowedStr("c"),
             Tuple { len: 2 },
             U16(1),
-            U32(0),
+            Bool(false),
             TupleEnd,
             StructEnd,
 
@@ -129,7 +129,7 @@ fn serialize_big_tree() {
             BorrowedStr("c"),
             Tuple { len: 2 },
             U16(2),
-            U32(0),
+            Bool(false),
             TupleEnd,
             StructEnd,
 
@@ -179,7 +179,7 @@ fn serialize_big_tree() {
             BorrowedStr("c"),
             Tuple { len: 2 },
             U16(6),
-            U32(0),
+            Bool(false),
             TupleEnd,
             StructEnd,
 

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -69,8 +69,6 @@ fn serialize_json_big_tree() {
     });
 
     let serialized = serde_json::to_string_pretty(&tree).unwrap();
-    print!("{}\n", serialized);
-
     let deserialized = serde_json::from_str::<TestNode>(&serialized).unwrap();
     assert_eq!(tree, deserialized);
 }

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -4,23 +4,23 @@ mod common;
 
 use common::TestLang;
 use cstree::{GreenNodeBuilder, NodeOrToken, SyntaxNode};
-use serde_test::{assert_tokens, Token::*};
+use serde_test::assert_tokens;
 
 type Rodeo = lasso::Rodeo<lasso::Spur, fxhash::FxBuildHasher>;
 
-fn build_tree() -> SyntaxNode<TestLang, (), Rodeo> {
+fn build_tree() -> SyntaxNode<TestLang, String, Rodeo> {
     let tree = common::big_tree();
     let mut builder = GreenNodeBuilder::new();
     common::build_recursive(&tree, &mut builder, 0);
     let (node, interner) = builder.finish();
 
-    SyntaxNode::<TestLang, (), _>::new_root_with_resolver(node, interner.unwrap())
+    SyntaxNode::<TestLang, _, _>::new_root_with_resolver(node, interner.unwrap())
 }
 
 /// Serializable SyntaxNode that doesn't have a identity `PartialEq` implementation,
 /// but checks if both trees have equal nodes and tokens.
 #[derive(Debug)]
-struct TestNode(SyntaxNode<TestLang, (), Rodeo>);
+struct TestNode(SyntaxNode<TestLang, String, Rodeo>);
 
 impl serde::Serialize for TestNode {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -43,6 +43,7 @@ impl<'de> serde::Deserialize<'de> for TestNode {
 impl PartialEq<TestNode> for TestNode {
     fn eq(&self, other: &TestNode) -> bool {
         self.0.kind() == other.0.kind()
+            && self.0.get_data() == other.0.get_data()
             && self.0.text_range() == other.0.text_range()
             && self
                 .0
@@ -61,34 +62,60 @@ impl PartialEq<TestNode> for TestNode {
 }
 
 #[test]
+fn serialize_json_big_tree() {
+    let tree = TestNode(build_tree());
+    tree.0.children().enumerate().for_each(|(idx, node)| {
+        node.set_data(format!("{}", idx));
+    });
+
+    let serialized = serde_json::to_string_pretty(&tree).unwrap();
+    print!("{}\n", serialized);
+
+    let deserialized = serde_json::from_str::<TestNode>(&serialized).unwrap();
+    assert_eq!(tree, deserialized);
+}
+
+#[test]
 fn serialize_big_tree() {
+    use serde_test::Token::*;
+
     let tree = TestNode(build_tree());
 
     #[rustfmt::skip]
     assert_tokens(
         &tree,
         &[
-            Seq { len: Option::None },
+            Tuple { len: 2 },
 
+            Seq { len: Option::Some(14) },
             Struct { name: "Event", len: 2 },
             BorrowedStr("t"),
             BorrowedStr("EnterNode"),
             BorrowedStr("c"),
+            Tuple { len: 2 },
             U16(0),
+            U32(0),
+            TupleEnd,
             StructEnd,
 
             Struct { name: "Event", len: 2 },
             BorrowedStr("t"),
             BorrowedStr("EnterNode"),
             BorrowedStr("c"),
+            Tuple { len: 2 },
             U16(1),
+            U32(0),
+            TupleEnd,
             StructEnd,
 
             Struct { name: "Event", len: 2 },
             BorrowedStr("t"),
             BorrowedStr("EnterNode"),
             BorrowedStr("c"),
+            Tuple { len: 2 },
             U16(2),
+            U32(0),
+            TupleEnd,
             StructEnd,
 
             Struct { name: "Event", len: 2 },
@@ -135,7 +162,10 @@ fn serialize_big_tree() {
             BorrowedStr("t"),
             BorrowedStr("EnterNode"),
             BorrowedStr("c"),
+            Tuple { len: 2 },
             U16(6),
+            U32(0),
+            TupleEnd,
             StructEnd,
 
             Struct { name: "Event", len: 2 },
@@ -177,8 +207,12 @@ fn serialize_big_tree() {
             BorrowedStr("t"),
             BorrowedStr("LeaveNode"),
             StructEnd,
-
             SeqEnd,
+
+            Seq { len: Option::Some(0) },
+            SeqEnd,
+
+            TupleEnd,
         ],
     );
 }

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "serde")]
+#![cfg(feature = "serde1")]
 
 mod common;
 

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "serde")]
+
 mod common;
 
 use common::TestLang;


### PR DESCRIPTION
Make `SyntaxNode` serializable by implementing `Serialize` and `Deserialize`.

A serialized tree is basically a list of events (`EnterNode`, `LeaveNode`, `Token`),
which are then used in conjunction with a `GreenNodeBuilder` to build up a new tree
that looks the same as the serialized one.

### TODO
- [x] Implement serialization for the data (`D`)


Resolves #4