### PR TITLE
Change `SyntaxNode`'s `Hash` and `Eq` to be based on pointer equality

### DIFF
--- a/src/green/node.rs
+++ b/src/green/node.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use fxhash::FxHasher32;
-use servo_arc::{Arc, HeaderSlice, HeaderWithLength, ThinArc};
+use servo_arc::{Arc, HeaderWithLength, ThinArc};
 
 use crate::{
     green::{GreenElement, GreenElementRef, PackedGreenElement, SyntaxKind},
@@ -121,11 +121,6 @@ impl GreenNode {
         Children {
             inner: self.data.slice.iter(),
         }
-    }
-
-    pub(crate) fn ptr(&self) -> *const u8 {
-        let r: &HeaderSlice<_, _> = &self.data;
-        r as *const _ as _
     }
 }
 

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -185,7 +185,7 @@ impl<L: Language, D, R> SyntaxNode<L, D, R> {
 // Identity semantics for hash & eq
 impl<L: Language, D, R> PartialEq for SyntaxNode<L, D, R> {
     fn eq(&self, other: &SyntaxNode<L, D, R>) -> bool {
-        self.green().ptr() == other.green().ptr() && self.text_range().start() == other.text_range().start()
+        self.data == other.data
     }
 }
 
@@ -193,8 +193,7 @@ impl<L: Language, D, R> Eq for SyntaxNode<L, D, R> {}
 
 impl<L: Language, D, R> Hash for SyntaxNode<L, D, R> {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        ptr::hash(self.green().ptr(), state);
-        self.text_range().start().hash(state);
+        ptr::hash(self.data, state);
     }
 }
 


### PR DESCRIPTION
Since we memoize the syntax (red) nodes, we should make use of the benefit that this is possible since the nodes don't get reallocated. See also https://github.com/rust-analyzer/rust-analyzer/blob/master/docs/dev/syntax.md#memoized-rednodes.