### PR TITLE
Use strict provenance for pointer tagging

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,7 +102,7 @@ jobs:
           rust-version: nightly
           components: miri
         env: 
-          MIRIFLAGS: -Zmiri-disable-isolation
+          MIRIFLAGS: -Zmiri-disable-isolation -Zmiri-strict-provenance
       - run: cargo miri test --verbose --all-features
         
   sanitizers:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ parking_lot = "0.11.2"
 
 # Arc
 triomphe = "0.1.3"
+sptr     = "0.3.2"
 
 [dependencies.serde]
 version          = "1.0"

--- a/src/green/element.rs
+++ b/src/green/element.rs
@@ -4,6 +4,8 @@ use std::{fmt, hash, mem};
 // This MUST be size=1 such that pointer math actually advances the pointer.
 type ErasedPtr = *const u8;
 
+use sptr::Strict;
+
 use crate::{
     green::{GreenNode, GreenToken, SyntaxKind},
     NodeOrToken, TextSize,
@@ -114,7 +116,7 @@ impl From<PackedGreenElement> for GreenElement {
 
 impl PackedGreenElement {
     pub(crate) fn is_node(&self) -> bool {
-        self.ptr as usize & 1 == 0
+        self.ptr.addr() & super::token::IS_TOKEN_TAG == 0
     }
 
     pub(crate) fn as_node(&self) -> Option<&GreenNode> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@
 
 #![forbid(missing_debug_implementations, unconditional_recursion)]
 #![deny(unsafe_code, missing_docs, future_incompatible)]
+#![allow(unstable_name_collisions)] // strict provenance - must come after `future_incompatible` to take precedence
 
 #[allow(unsafe_code)]
 mod green;

--- a/src/syntax/node.rs
+++ b/src/syntax/node.rs
@@ -387,7 +387,8 @@ impl<L: Language, D> SyntaxNode<L, D> {
     /// builder.token(TOKEN, "content");
     /// builder.finish_node();
     /// let (green, cache) = builder.finish();
-    /// let root: ResolvedNode<Lang> = SyntaxNode::new_root_with_resolver(green, cache.unwrap().into_interner().unwrap());
+    /// let root: ResolvedNode<Lang> =
+    ///     SyntaxNode::new_root_with_resolver(green, cache.unwrap().into_interner().unwrap());
     /// assert_eq!(root.text(), "content");
     /// ```
     #[inline]

--- a/src/syntax/token.rs
+++ b/src/syntax/token.rs
@@ -253,7 +253,12 @@ impl<L: Language, D> SyntaxToken<L, D> {
     /// let tree = parse(&mut builder, "x");
     /// # let tree = SyntaxNode::<Lang>::new_root(builder.finish().0);
     /// let type_table = &state.type_table;
-    /// let ident = tree.children_with_tokens().next().unwrap().into_token().unwrap();
+    /// let ident = tree
+    ///     .children_with_tokens()
+    ///     .next()
+    ///     .unwrap()
+    ///     .into_token()
+    ///     .unwrap();
     /// let typ = type_table.type_of(ident.text_key());
     /// ```
     #[inline]


### PR DESCRIPTION
Since we support stable, this uses the [`sptr` crate](https://crates.io/crates/sptr) to get access to the otherwise nightly [strict provenance](https://doc.rust-lang.org/nightly/std/ptr/index.html#strict-provenance) methods.