### PR TITLE
Performance Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
  * Introduced `Language::static_text` to optimize tokens that always appear with the same text (estimated 10-15% faster tree building when used, depending on the ratio of static to dynamic tokens).
    * Since `cstree`s are lossless, `GreenNodeBuilder::token` must still be passed the source text even for static tokens. 
  * Internal performance improvements for up to 10% faster tree building by avoiding unnecessary duplication of elements.
+ * Use `NonNull` for the internal representation of `SyntaxNode`, meaning it now benefits from niche optimizations (`Option<SyntaxNode>` is now the same size as `SyntaxNode` itself: the size of a pointer).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## `v0.12.0`
+
+ * Introduced `Language::static_text` to optimize tokens that always appear with the same text (estimated 10-15% faster tree building when used, depending on the ratio of static to dynamic tokens).
+   * Since `cstree`s are lossless, `GreenNodeBuilder::token` must still be passed the source text even for static tokens. 
+ * Internal performance improvements for up to 10% faster tree building by avoiding unnecessary duplication of elements.

--- a/examples/math.rs
+++ b/examples/math.rs
@@ -88,7 +88,7 @@ impl<'input, I: Iterator<Item = (SyntaxKind, &'input str)>> Parser<'input, I> {
 
     fn bump(&mut self) {
         if let Some((token, string)) = self.iter.next() {
-            self.builder.token_with_text(token, string);
+            self.builder.token(token, string);
         }
     }
 

--- a/examples/s_expressions.rs
+++ b/examples/s_expressions.rs
@@ -187,7 +187,7 @@ fn parse(text: &str) -> Parse<impl Resolver> {
         /// Advance one token, adding it to the current branch of the tree builder.
         fn bump(&mut self) {
             let (kind, text) = self.tokens.pop_front().unwrap();
-            self.builder.token_with_text(kind, text);
+            self.builder.token(kind, text);
         }
 
         /// Peek at the first unprocessed token

--- a/examples/s_expressions.rs
+++ b/examples/s_expressions.rs
@@ -52,6 +52,14 @@ impl cstree::Language for Lang {
     fn kind_to_raw(kind: Self::Kind) -> cstree::SyntaxKind {
         kind.into()
     }
+
+    fn static_text(kind: Self::Kind) -> Option<&'static str> {
+        match kind {
+            LParen => Some("("),
+            RParen => Some(")"),
+            _ => None,
+        }
+    }
 }
 
 /// GreenNode is an immutable tree, which caches identical nodes and tokens, but doesn't contain
@@ -60,7 +68,7 @@ impl cstree::Language for Lang {
 /// the Resolver to get the real text back from the interned representation.
 use cstree::{
     interning::{IntoResolver, Resolver},
-    GreenNode,
+    GreenNode, Language,
 };
 
 /// You can construct GreenNodes by hand, but a builder is helpful for top-down parsers: it maintains
@@ -84,7 +92,7 @@ fn parse(text: &str) -> Parse<impl Resolver> {
         /// input tokens, including whitespace.
         tokens:  VecDeque<(SyntaxKind, &'input str)>,
         /// the in-progress green tree.
-        builder: GreenNodeBuilder<'static, 'static>,
+        builder: GreenNodeBuilder<'static, 'static, Lang>,
         /// the list of syntax errors we've accumulated so far.
         errors:  Vec<String>,
     }
@@ -102,13 +110,13 @@ fn parse(text: &str) -> Parse<impl Resolver> {
     impl Parser<'_> {
         fn parse(mut self) -> Parse<impl Resolver> {
             // Make sure that the root node covers all source
-            self.builder.start_node(Root.into());
+            self.builder.start_node(Root);
             // Parse zero or more S-expressions
             loop {
                 match self.sexp() {
                     SexpRes::Eof => break,
                     SexpRes::RParen => {
-                        self.builder.start_node(Error.into());
+                        self.builder.start_node(Error);
                         self.errors.push("unmatched `)`".to_string());
                         self.bump(); // be sure to advance even in case of an error, so as to not get stuck
                         self.builder.finish_node();
@@ -135,7 +143,7 @@ fn parse(text: &str) -> Parse<impl Resolver> {
         fn list(&mut self) {
             assert_eq!(self.current(), Some(LParen));
             // Start the list node
-            self.builder.start_node(List.into());
+            self.builder.start_node(List);
             self.bump(); // '('
             loop {
                 match self.sexp() {
@@ -166,7 +174,7 @@ fn parse(text: &str) -> Parse<impl Resolver> {
             match t {
                 LParen => self.list(),
                 Word => {
-                    self.builder.start_node(Atom.into());
+                    self.builder.start_node(Atom);
                     self.bump();
                     self.builder.finish_node();
                 }
@@ -179,7 +187,7 @@ fn parse(text: &str) -> Parse<impl Resolver> {
         /// Advance one token, adding it to the current branch of the tree builder.
         fn bump(&mut self) {
             let (kind, text) = self.tokens.pop_front().unwrap();
-            self.builder.token(kind.into(), text);
+            self.builder.token_with_text(kind, text);
         }
 
         /// Peek at the first unprocessed token
@@ -348,7 +356,9 @@ impl ast::Atom {
 
     fn text<'r>(&self, resolver: &'r impl Resolver) -> &'r str {
         match &self.0.green().children().next() {
-            Some(cstree::NodeOrToken::Token(token)) => token.text(resolver),
+            Some(cstree::NodeOrToken::Token(token)) => Lang::static_text(Lang::kind_from_raw(token.kind()))
+                .or_else(|| token.text(resolver))
+                .unwrap(),
             _ => unreachable!(),
         }
     }

--- a/src/green.rs
+++ b/src/green.rs
@@ -26,12 +26,12 @@ pub struct SyntaxKind(pub u16);
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use node::GreenNodeHead;
     use token::GreenTokenData;
 
-    use super::*;
-
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn assert_send_sync() {
         fn f<T: Send + Sync>() {}
         f::<GreenNode>();
@@ -41,6 +41,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     #[rustfmt::skip]
     fn assert_green_sizes() {
         use std::mem::size_of;

--- a/src/green/builder.rs
+++ b/src/green/builder.rs
@@ -34,7 +34,7 @@ impl NodeCache<'static> {
     /// tokens. To re-use an existing interner, see [`with_interner`](NodeCache::with_interner).
     /// # Examples
     /// ```
-    /// # use cstree::doctest::{*, Language as _};
+    /// # use cstree::testing::{*, Language as _};
     /// // Build a tree
     /// let mut cache = NodeCache::new();
     /// let mut builder: GreenNodeBuilder<MyLanguage> = GreenNodeBuilder::with_cache(&mut cache);
@@ -72,7 +72,7 @@ where
     /// (strings) across tokens.
     /// # Examples
     /// ```
-    /// # use cstree::doctest::{*, Language as _};
+    /// # use cstree::testing::{*, Language as _};
     /// use lasso::Rodeo;
     ///
     /// // Create the builder from a custom `Rodeo`
@@ -106,7 +106,7 @@ where
     /// (strings) across tokens.
     /// # Examples
     /// ```
-    /// # use cstree::doctest::{*, Language as _};
+    /// # use cstree::testing::{*, Language as _};
     /// use lasso::Rodeo;
     ///
     /// // Create the builder from a custom `Rodeo`
@@ -245,7 +245,7 @@ pub struct Checkpoint(usize);
 ///
 /// # Examples
 /// ```
-/// # use cstree::doctest::{*, Language as _};
+/// # use cstree::testing::{*, Language as _};
 /// # use cstree::interning::IntoResolver;
 /// // Build a tree
 /// let mut builder: GreenNodeBuilder<MyLanguage> = GreenNodeBuilder::new();
@@ -305,7 +305,7 @@ where
     /// The `cache` given will be returned on [`finish`](GreenNodeBuilder::finish).
     /// # Examples
     /// ```
-    /// # use cstree::doctest::{*, Language as _};
+    /// # use cstree::testing::{*, Language as _};
     /// // Construct a builder from our own cache
     /// let cache = NodeCache::new();
     /// let mut builder: GreenNodeBuilder<MyLanguage> = GreenNodeBuilder::from_cache(cache);
@@ -366,7 +366,7 @@ where
     /// This is the same interner as used by the underlying [`NodeCache`].
     /// # Examples
     /// ```
-    /// # use cstree::doctest::*;
+    /// # use cstree::testing::*;
     /// # use cstree::interning::*;
     /// let mut builder: GreenNodeBuilder<MyLanguage> = GreenNodeBuilder::new();
     /// let interner = builder.interner_mut();
@@ -426,7 +426,7 @@ where
     ///
     /// # Examples
     /// ```
-    /// # use cstree::doctest::*;
+    /// # use cstree::testing::*;
     /// # use cstree::{GreenNodeBuilder, Language};
     /// # struct Parser;
     /// # impl Parser {

--- a/src/green/token.rs
+++ b/src/green/token.rs
@@ -11,7 +11,7 @@ use triomphe::Arc;
 #[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
 pub(super) struct GreenTokenData {
     pub(super) kind:     SyntaxKind,
-    pub(super) text:     Key,
+    pub(super) text:     Option<Key>,
     pub(super) text_len: TextSize,
 }
 
@@ -60,11 +60,11 @@ impl GreenToken {
 
     /// The original source text of this Token.
     #[inline]
-    pub fn text<'i, I>(&self, resolver: &'i I) -> &'i str
+    pub fn text<'i, I>(&self, resolver: &'i I) -> Option<&'i str>
     where
         I: Resolver + ?Sized,
     {
-        resolver.resolve(&self.data().text)
+        self.data().text.map(|key| resolver.resolve(&key))
     }
 
     /// Returns the length of text covered by this token.
@@ -78,7 +78,7 @@ impl GreenToken {
     ///
     /// See also [`text`](GreenToken::text).
     #[inline]
-    pub fn text_key(&self) -> Key {
+    pub fn text_key(&self) -> Option<Key> {
         self.data().text
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,11 +106,17 @@ pub use triomphe::Arc;
 pub trait Language: Sized + Clone + Copy + fmt::Debug + Eq + Ord + std::hash::Hash {
     /// A type that represents what items in your Language can be.
     /// Typically, this is an `enum` with variants such as `Identifier`, `Literal`, ...
-    type Kind: fmt::Debug;
+    type Kind: Sized + Clone + Copy + fmt::Debug;
 
     /// Construct a semantic item kind from the compact representation.
     fn kind_from_raw(raw: SyntaxKind) -> Self::Kind;
 
     /// Convert a semantic item kind into a more compact representation.
     fn kind_to_raw(kind: Self::Kind) -> SyntaxKind;
+
+    /// Fixed text for a particular syntax kind.
+    ///
+    /// Implement for kinds that will only ever represent the same text, such as specific
+    /// punctuation (like a semicolon) or operators (like `<=`).
+    fn static_text(kind: Self::Kind) -> Option<&'static str>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,18 +70,21 @@ pub use crate::{
 };
 pub use triomphe::Arc;
 
-/// The `Language` trait is the bridge between the internal `cstree` representation and your language
-/// types.
-/// This is essential to providing a [`SyntaxNode`] API that can be used with your types, as in the
+/// The `Language` trait is the bridge between the internal `cstree` representation and your
+/// language's types.
+/// This is essential for providing a [`SyntaxNode`] API that can be used with your types, as in the
 /// `s_expressions` example:
+///
 /// ```
 /// #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// # #[allow(non_camel_case_types)]
 /// #[repr(u16)]
 /// enum SyntaxKind {
-///     ROOT,       // top-level node
-///     ATOM,       // `+`, `15`
-///     WHITESPACE, // whitespaces is explicit
+///     Plus,       // `+`
+///     Minus,      // `-`
+///     Integer,    // like `15`
+///     Expression, // combined expression, like `5 + 4 - 3`
+///     Whitespace, // whitespaces is explicit
 ///     #[doc(hidden)]
 ///     __LAST,
 /// }
@@ -101,6 +104,14 @@ pub use triomphe::Arc;
 ///     fn kind_to_raw(kind: Self::Kind) -> cstree::SyntaxKind {
 ///         cstree::SyntaxKind(kind as u16)
 ///     }
+///
+///     fn static_text(kind: Self::Kind) -> Option<&'static str> {
+///         match kind {
+///             Plus => Some("+"),
+///             Minus => Some("-"),
+///             _ => None,
+///         }
+///     }
 /// }
 /// ```
 pub trait Language: Sized + Clone + Copy + fmt::Debug + Eq + Ord + std::hash::Hash {
@@ -116,7 +127,52 @@ pub trait Language: Sized + Clone + Copy + fmt::Debug + Eq + Ord + std::hash::Ha
 
     /// Fixed text for a particular syntax kind.
     ///
-    /// Implement for kinds that will only ever represent the same text, such as specific
-    /// punctuation (like a semicolon) or operators (like `<=`).
+    /// Implement for kinds that will only ever represent the same text, such as punctuation (like a
+    /// semicolon), keywords (like `fn`), or operators (like `<=`).
     fn static_text(kind: Self::Kind) -> Option<&'static str>;
+}
+
+#[doc(hidden)]
+#[allow(unsafe_code, unused)]
+pub mod doctest {
+    pub use crate::*;
+    pub fn parse<L: Language, I>(_b: &mut super::GreenNodeBuilder<L, I>, _s: &str) {}
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    #[repr(u16)]
+    #[allow(non_camel_case_types)]
+    pub enum TestSyntaxKind {
+        Plus,
+        Identifier,
+        Int,
+        Float,
+        Operation,
+        Root,
+        Whitespace,
+        __LAST,
+    }
+    pub use TestSyntaxKind::*;
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    pub enum TestLang {}
+    pub type MyLanguage = TestLang;
+    impl Language for TestLang {
+        type Kind = TestSyntaxKind;
+
+        fn kind_from_raw(raw: SyntaxKind) -> Self::Kind {
+            assert!(raw.0 <= TestSyntaxKind::__LAST as u16);
+            unsafe { std::mem::transmute::<u16, TestSyntaxKind>(raw.0) }
+        }
+
+        fn kind_to_raw(kind: Self::Kind) -> SyntaxKind {
+            SyntaxKind(kind as u16)
+        }
+
+        fn static_text(kind: Self::Kind) -> Option<&'static str> {
+            match kind {
+                TestSyntaxKind::Plus => Some("+"),
+                _ => None,
+            }
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,7 @@ pub trait Language: Sized + Clone + Copy + fmt::Debug + Eq + Ord + std::hash::Ha
 
 #[doc(hidden)]
 #[allow(unsafe_code, unused)]
-pub mod doctest {
+pub mod testing {
     pub use crate::*;
     pub fn parse<L: Language, I>(_b: &mut super::GreenNodeBuilder<L, I>, _s: &str) {}
 

--- a/src/serde_impls.rs
+++ b/src/serde_impls.rs
@@ -177,16 +177,16 @@ where
             where
                 A: SeqAccess<'de>,
             {
-                let mut builder = GreenNodeBuilder::new();
+                let mut builder: GreenNodeBuilder<L> = GreenNodeBuilder::new();
                 let mut data_indices = VecDeque::new();
 
                 while let Some(next) = seq.next_element::<Event<'_>>()? {
                     match next {
                         Event::EnterNode(kind, has_data) => {
-                            builder.start_node(kind);
+                            builder.start_node(L::kind_from_raw(kind));
                             data_indices.push_back(has_data);
                         }
-                        Event::Token(kind, text) => builder.token(kind, text),
+                        Event::Token(kind, text) => builder.token(L::kind_from_raw(kind), text),
                         Event::LeaveNode => builder.finish_node(),
                     }
                 }

--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -33,3 +33,34 @@ pub use text::SyntaxText;
 // this.
 //
 //   - DQ 01/2021
+
+#[cfg(test)]
+mod tests {
+    use crate::testing::*;
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn assert_send_sync() {
+        fn f<T: Send + Sync>() {}
+        f::<SyntaxNode<TestLang>>();
+        f::<SyntaxToken<TestLang>>();
+        f::<SyntaxElement<TestLang>>();
+        f::<SyntaxElementRef<'static, TestLang>>();
+
+        f::<ResolvedNode<TestLang>>();
+        f::<ResolvedToken<TestLang>>();
+        f::<ResolvedElement<TestLang>>();
+        f::<ResolvedElementRef<'static, TestLang>>();
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    #[rustfmt::skip]
+    fn assert_syntax_sizes() {
+        use std::mem::size_of;
+
+        assert_eq!(size_of::<SyntaxNode<TestLang>>(),          size_of::<*const u8>());
+        assert_eq!(size_of::<Option<SyntaxNode<TestLang>>>(),  size_of::<*const u8>()); // verify niche opt of `NonNull`
+        assert_eq!(size_of::<SyntaxToken<TestLang>>(),         size_of::<*const u8>() + size_of::<u32>() * 2);
+    }
+}

--- a/src/syntax/node.rs
+++ b/src/syntax/node.rs
@@ -294,34 +294,13 @@ impl<L: Language, D> SyntaxNode<L, D> {
     ///
     /// # Example
     /// ```
-    /// # use cstree::*;
-    /// # #[allow(non_camel_case_types)]
-    /// #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    /// #[repr(u16)]
-    /// enum SyntaxKind {
-    ///     ROOT,
-    /// }
-    /// #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    /// enum Lang {}
-    /// impl cstree::Language for Lang {
-    ///     // ...
-    /// #     type Kind = SyntaxKind;
-    /// #
-    /// #     fn kind_from_raw(raw: cstree::SyntaxKind) -> Self::Kind {
-    /// #         assert!(raw.0 <= SyntaxKind::ROOT as u16);
-    /// #         unsafe { std::mem::transmute::<u16, SyntaxKind>(raw.0) }
-    /// #     }
-    /// #
-    /// #     fn kind_to_raw(kind: Self::Kind) -> cstree::SyntaxKind {
-    /// #         cstree::SyntaxKind(kind as u16)
-    /// #     }
-    /// }
-    /// # let mut builder = GreenNodeBuilder::new();
-    /// # builder.start_node(SyntaxKind(0));
+    /// # use cstree::doctest::*;
+    /// # let mut builder: GreenNodeBuilder<MyLanguage> = GreenNodeBuilder::new();
+    /// # builder.start_node(Root);
     /// # builder.finish_node();
-    /// # let (green, _) = builder.finish();
-    /// let root: SyntaxNode<Lang> = SyntaxNode::new_root(green);
-    /// assert_eq!(root.kind(), SyntaxKind::ROOT);
+    /// # let (green_root, _) = builder.finish();
+    /// let root: SyntaxNode<MyLanguage> = SyntaxNode::new_root(green_root);
+    /// assert_eq!(root.kind(), Root);
     /// ```
     #[inline]
     pub fn new_root(green: GreenNode) -> Self {
@@ -356,38 +335,18 @@ impl<L: Language, D> SyntaxNode<L, D> {
     ///
     /// # Example
     /// ```
-    /// # use cstree::*;
-    /// # #[allow(non_camel_case_types)]
-    /// #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    /// #[repr(u16)]
-    /// enum SyntaxKind {
-    ///     TOKEN,
-    ///     ROOT,
-    /// }
-    /// #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    /// enum Lang {}
-    /// impl cstree::Language for Lang {
-    ///     // ...
-    /// #     type Kind = SyntaxKind;
-    /// #
-    /// #     fn kind_from_raw(raw: cstree::SyntaxKind) -> Self::Kind {
-    /// #         assert!(raw.0 <= SyntaxKind::ROOT as u16);
-    /// #         unsafe { std::mem::transmute::<u16, SyntaxKind>(raw.0) }
-    /// #     }
-    /// #
-    /// #     fn kind_to_raw(kind: Self::Kind) -> cstree::SyntaxKind {
-    /// #         cstree::SyntaxKind(kind as u16)
-    /// #     }
-    /// }
-    /// # const ROOT: cstree::SyntaxKind = cstree::SyntaxKind(0);
-    /// # const TOKEN: cstree::SyntaxKind = cstree::SyntaxKind(1);
-    /// # type SyntaxNode<L> = cstree::SyntaxNode<L, ()>;
-    /// let mut builder = GreenNodeBuilder::new();
-    /// builder.start_node(ROOT);
-    /// builder.token(TOKEN, "content");
+    /// # use cstree::doctest::*;
+    /// let mut builder: GreenNodeBuilder<MyLanguage> = GreenNodeBuilder::new();
+    /// builder.start_node(Root);
+    /// builder.token(Identifier, "content");
     /// builder.finish_node();
     /// let (green, cache) = builder.finish();
-    /// let root: ResolvedNode<Lang> = SyntaxNode::new_root_with_resolver(green, cache.unwrap().into_interner().unwrap());
+    ///
+    /// // We are safe to use `unwrap` here because we created the builder with `new`.
+    /// // This created a new interner and cache for us owned by the builder,
+    /// // and `finish` always returns these.
+    /// let interner = cache.unwrap().into_interner().unwrap();
+    /// let root: ResolvedNode<MyLanguage> = SyntaxNode::new_root_with_resolver(green, interner);
     /// assert_eq!(root.text(), "content");
     /// ```
     #[inline]

--- a/src/syntax/node.rs
+++ b/src/syntax/node.rs
@@ -11,7 +11,8 @@ use std::{
     cell::UnsafeCell,
     fmt,
     hash::{Hash, Hasher},
-    iter, ptr,
+    iter,
+    ptr::{self, NonNull},
     sync::{
         atomic::{AtomicU32, Ordering},
         Arc as StdArc,
@@ -26,7 +27,7 @@ use triomphe::Arc;
 #[derive(Debug)]
 #[repr(transparent)]
 pub struct SyntaxNode<L: Language, D: 'static = ()> {
-    data: *mut NodeData<L, D>,
+    data: NonNull<NodeData<L, D>>,
 }
 
 unsafe impl<L: Language, D: 'static> Send for SyntaxNode<L, D> {}
@@ -158,7 +159,7 @@ impl<L: Language, D> Drop for SyntaxNode<L, D> {
             root.drop_recursive();
             let root_data = root.data;
             drop(root);
-            unsafe { drop(Box::from_raw(root_data)) };
+            unsafe { drop(Box::from_raw(root_data.as_ptr())) };
             unsafe { drop(Box::from_raw(ref_count)) };
         }
     }
@@ -167,7 +168,7 @@ impl<L: Language, D> Drop for SyntaxNode<L, D> {
 impl<L: Language, D> SyntaxNode<L, D> {
     #[inline]
     fn data(&self) -> &NodeData<L, D> {
-        unsafe { &*self.data }
+        unsafe { self.data.as_ref() }
     }
 
     #[inline]
@@ -209,7 +210,7 @@ impl<L: Language, D> SyntaxNode<L, D> {
                 // safety: since there are no more `parent` pointers from the children of the
                 // node this data belonged to, and we have just dropped the node, there are now
                 // no more references to `data`
-                let data = unsafe { Box::from_raw(data) };
+                let data = unsafe { Box::from_raw(data.as_ptr()) };
                 drop(data);
             }
         }
@@ -227,7 +228,7 @@ impl<L: Language, D> Eq for SyntaxNode<L, D> {}
 
 impl<L: Language, D> Hash for SyntaxNode<L, D> {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        ptr::hash(self.data, state);
+        self.data.hash(state);
     }
 }
 
@@ -251,7 +252,7 @@ impl<L: Language, D> Kind<L, D> {
 
 pub(super) struct NodeData<L: Language, D: 'static> {
     kind:        Kind<L, D>,
-    green:       ptr::NonNull<GreenNode>,
+    green:       NonNull<GreenNode>,
     ref_count:   *mut AtomicU32,
     data:        RwLock<Option<Arc<D>>>,
     children:    Vec<UnsafeCell<Option<SyntaxElement<L, D>>>>,
@@ -259,24 +260,21 @@ pub(super) struct NodeData<L: Language, D: 'static> {
 }
 
 impl<L: Language, D> NodeData<L, D> {
-    fn new(
-        kind: Kind<L, D>,
-        green: ptr::NonNull<GreenNode>,
-        ref_count: *mut AtomicU32,
-        n_children: usize,
-    ) -> *mut Self {
+    fn new(kind: Kind<L, D>, green: NonNull<GreenNode>, ref_count: *mut AtomicU32, n_children: usize) -> NonNull<Self> {
         let mut children = Vec::with_capacity(n_children);
         let mut child_locks = Vec::with_capacity(n_children);
         children.extend((0..n_children).map(|_| Default::default()));
         child_locks.extend((0..n_children).map(|_| Default::default()));
-        Box::into_raw(Box::new(Self {
+        let ptr = Box::into_raw(Box::new(Self {
             kind,
             green,
             ref_count,
             data: RwLock::default(),
             children,
             child_locks,
-        }))
+        }));
+        // safety: guaranteed by `Box::into_raw`
+        unsafe { NonNull::new_unchecked(ptr) }
     }
 }
 
@@ -285,7 +283,7 @@ impl<L: Language, D> SyntaxNode<L, D> {
     ///
     /// # Example
     /// ```
-    /// # use cstree::doctest::*;
+    /// # use cstree::testing::*;
     /// # let mut builder: GreenNodeBuilder<MyLanguage> = GreenNodeBuilder::new();
     /// # builder.start_node(Root);
     /// # builder.finish_node();
@@ -298,7 +296,7 @@ impl<L: Language, D> SyntaxNode<L, D> {
         Self::make_new_root(green, None)
     }
 
-    pub(super) fn new(data: *mut NodeData<L, D>) -> Self {
+    fn new(data: NonNull<NodeData<L, D>>) -> Self {
         Self { data }
     }
 
@@ -307,12 +305,12 @@ impl<L: Language, D> SyntaxNode<L, D> {
         let n_children = green.children().count();
         let data = NodeData::new(
             Kind::Root(green, resolver),
-            ptr::NonNull::dangling(),
+            NonNull::dangling(),
             Box::into_raw(ref_count),
             n_children,
         );
         let ret = Self::new(data);
-        let green: ptr::NonNull<GreenNode> = match &ret.data().kind {
+        let green: NonNull<GreenNode> = match &ret.data().kind {
             Kind::Root(green, _resolver) => green.into(),
             _ => unreachable!(),
         };
@@ -320,7 +318,7 @@ impl<L: Language, D> SyntaxNode<L, D> {
         // Also, we use `addr_of_mut` here in order to not have to go through a `&mut *ret.data`,
         // which would invalidate the reading provenance of `green`, since `green` is contained in
         // the date once we have written it here.
-        unsafe { ptr::addr_of_mut!((*ret.data).green).write(green) };
+        unsafe { ptr::addr_of_mut!((*ret.data.as_ptr()).green).write(green) };
         ret
     }
 
@@ -329,7 +327,7 @@ impl<L: Language, D> SyntaxNode<L, D> {
     ///
     /// # Example
     /// ```
-    /// # use cstree::doctest::*;
+    /// # use cstree::testing::*;
     /// let mut builder: GreenNodeBuilder<MyLanguage> = GreenNodeBuilder::new();
     /// builder.start_node(Root);
     /// builder.token(Identifier, "content");
@@ -443,7 +441,7 @@ impl<L: Language, D> SyntaxNode<L, D> {
                     ref_count.fetch_add(2, Ordering::AcqRel);
                     let node_data = node.data;
                     drop(node);
-                    unsafe { drop(Box::from_raw(node_data)) };
+                    unsafe { drop(Box::from_raw(node_data.as_ptr())) };
                 }
                 SyntaxElement::Token(token) => {
                     // We don't have to worry about `NodeData` or `SyntaxToken<L>`'s own `Drop` here,

--- a/src/syntax/resolved.rs
+++ b/src/syntax/resolved.rs
@@ -198,7 +198,10 @@ impl<L: Language, D> ResolvedToken<L, D> {
     /// Uses the resolver associated with this tree to return the source text of this token.
     #[inline]
     pub fn text(&self) -> &str {
-        self.green().text(&**self.resolver())
+        // one of the two must be present upon construction
+        self.static_text()
+            .or_else(|| self.green().text(&**self.resolver()))
+            .unwrap()
     }
 }
 
@@ -732,7 +735,7 @@ fn assert_send_sync() {
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
     enum L {}
-    #[derive(Debug)]
+    #[derive(Debug, Clone, Copy)]
     enum Kind {
         Var,
     }
@@ -745,6 +748,10 @@ fn assert_send_sync() {
 
         fn kind_to_raw(_: Self::Kind) -> SyntaxKind {
             SyntaxKind(0)
+        }
+
+        fn static_text(_kind: Self::Kind) -> Option<&'static str> {
+            None
         }
     }
     fn f<T: Send + Sync>() {}

--- a/src/syntax/resolved.rs
+++ b/src/syntax/resolved.rs
@@ -728,35 +728,3 @@ impl<'a, L: Language, D> ResolvedElementRef<'a, L, D> {
         }
     }
 }
-
-#[test]
-fn assert_send_sync() {
-    use crate::SyntaxKind;
-
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-    enum L {}
-    #[derive(Debug, Clone, Copy)]
-    enum Kind {
-        Var,
-    }
-    impl Language for L {
-        type Kind = Kind;
-
-        fn kind_from_raw(_: SyntaxKind) -> Self::Kind {
-            Kind::Var
-        }
-
-        fn kind_to_raw(_: Self::Kind) -> SyntaxKind {
-            SyntaxKind(0)
-        }
-
-        fn static_text(_kind: Self::Kind) -> Option<&'static str> {
-            None
-        }
-    }
-    fn f<T: Send + Sync>() {}
-    f::<ResolvedNode<L>>();
-    f::<ResolvedToken<L>>();
-    f::<ResolvedElement<L>>();
-    f::<ResolvedElementRef<'static, L>>();
-}

--- a/src/syntax/text.rs
+++ b/src/syntax/text.rs
@@ -13,7 +13,7 @@ use crate::{interning::Resolver, Language, SyntaxNode, SyntaxToken, TextRange, T
 ///
 /// # Example
 /// ```
-/// # use cstree::doctest::*;
+/// # use cstree::testing::*;
 /// # use cstree::interning::IntoResolver;
 /// #
 /// fn parse_float_literal(s: &str) -> ResolvedNode<MyLanguage> {

--- a/src/syntax/text.rs
+++ b/src/syntax/text.rs
@@ -412,13 +412,30 @@ mod tests {
         fn kind_to_raw(kind: Self::Kind) -> SyntaxKind {
             kind
         }
+
+        fn static_text(kind: Self::Kind) -> Option<&'static str> {
+            let raw = Self::kind_to_raw(kind);
+            if raw == SyntaxKind(1) {
+                Some("{")
+            } else if raw == SyntaxKind(2) {
+                Some("}")
+            } else {
+                None
+            }
+        }
     }
 
     fn build_tree(chunks: &[&str]) -> (SyntaxNode<TestLang, ()>, impl Resolver) {
-        let mut builder = GreenNodeBuilder::new();
+        let mut builder: GreenNodeBuilder<TestLang> = GreenNodeBuilder::new();
         builder.start_node(SyntaxKind(62));
         for &chunk in chunks.iter() {
-            builder.token(SyntaxKind(92), chunk);
+            if chunk == "{" {
+                builder.token(SyntaxKind(1));
+            } else if chunk == "}" {
+                builder.token(SyntaxKind(2));
+            } else {
+                builder.token_with_text(SyntaxKind(92), chunk);
+            }
         }
         builder.finish_node();
         let (node, cache) = builder.finish();

--- a/src/syntax/token.rs
+++ b/src/syntax/token.rs
@@ -190,7 +190,7 @@ impl<L: Language, D> SyntaxToken<L, D> {
     /// [`Language::static_text`] for it, we can retrieve this text in the resulting syntax tree.
     ///
     /// ```
-    /// # use cstree::doctest::*;
+    /// # use cstree::testing::*;
     /// let mut builder: GreenNodeBuilder<MyLanguage> = GreenNodeBuilder::new();
     /// # builder.start_node(Root);
     /// # builder.token(Identifier, "x");
@@ -228,7 +228,7 @@ impl<L: Language, D> SyntaxToken<L, D> {
     ///  
     /// # Examples
     /// ```
-    /// # use cstree::doctest::*;
+    /// # use cstree::testing::*;
     /// let mut builder: GreenNodeBuilder<MyLanguage> = GreenNodeBuilder::new();
     /// # builder.start_node(Root);
     /// # builder.token(Identifier, "x");
@@ -277,7 +277,7 @@ impl<L: Language, D> SyntaxToken<L, D> {
     /// token's text keys to cross-reference between the syntax tree and the rest of your
     /// implementation by re-using the interner in both.
     /// ```
-    /// # use cstree::doctest::*;
+    /// # use cstree::testing::*;
     /// use cstree::interning::{new_interner, Hasher, Key, Rodeo};
     /// struct TypeTable {
     ///     // ...

--- a/src/syntax/token.rs
+++ b/src/syntax/token.rs
@@ -182,57 +182,31 @@ impl<L: Language, D> SyntaxToken<L, D> {
         self.static_text().or_else(|| self.green().text(resolver)).unwrap()
     }
 
-    /// If the syntax kind of this token always represents the same text, retrieve that text.
+    /// If the [syntax kind](Language::Kind) of this token always represents the same text, returns
+    /// that text.
     ///
     /// # Examples
-    /// If there is a `SyntaxKind::Plus` that represents just the `+` operator and we implement
-    /// [`Language::static_text`] for it, we can retrieve this text in the resulting syntax tree. ```
-    /// # use cstree::*;
-    /// # #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    /// # #[repr(u16)]
-    /// # enum SyntaxKind {
-    /// #     ROOT,
-    /// #     IDENT,
-    /// #     INT,
-    /// #     OP,
-    /// #     WS,
-    /// # }
-    /// # use SyntaxKind::*;
-    /// # #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    /// # enum Lang {}
-    /// # impl cstree::Language for Lang {
-    /// #     type Kind = SyntaxKind;
-    /// #
-    /// #     fn kind_from_raw(raw: cstree::SyntaxKind) -> Self::Kind {
-    /// #         assert!(raw.0 <= SyntaxKind::WS as u16);
-    /// #         unsafe { std::mem::transmute::<u16, SyntaxKind>(raw.0) }
-    /// #     }
-    /// #
-    /// #     fn kind_to_raw(kind: Self::Kind) -> cstree::SyntaxKind {
-    /// #         cstree::SyntaxKind(kind as u16)
-    /// #     }
-    /// #
-    /// #     fn static_text(kind: Self::Kind) -> Option<&'static str> {
-    /// #         match kind {
-    /// #             OP => "+",
-    /// #             _ => None,
-    /// #         }
-    /// #     }
-    /// # }
-    /// # type SyntaxNode<L> = cstree::SyntaxNode<L, ()>;
-    /// # fn parse(b: &mut GreenNodeBuilder<Rodeo>, s: &str) {}
-    /// #
-    /// let mut builder = GreenNodeBuilder::new();
-    /// # builder.start_node(ROOT);
-    /// # builder.token_with_text(IDENT, "x");
-    /// # builder.token_with_text(WS, " ");
-    /// # builder.token(OP);
-    /// # builder.token_with_text(WS, " ");
-    /// # builder.token_with_text(INT, "3");
+    /// If there is a syntax kind `Plus` that represents just the `+` operator and we implement
+    /// [`Language::static_text`] for it, we can retrieve this text in the resulting syntax tree.
+    ///
+    /// ```
+    /// # use cstree::doctest::*;
+    /// let mut builder: GreenNodeBuilder<MyLanguage> = GreenNodeBuilder::new();
+    /// # builder.start_node(Root);
+    /// # builder.token(Identifier, "x");
+    /// # builder.token(Whitespace, " ");
+    /// # builder.token(Plus, "+");
+    /// # builder.token(Whitespace, " ");
+    /// # builder.token(Int, "3");
     /// # builder.finish_node();
-    /// # let tree = SyntaxNode::<Lang>::new_root(builder.finish().0);
     /// let tree = parse(&mut builder, "x + 3");
-    /// let plus = tree.children_with_tokens().nth(2).unwrap().into_token().unwrap();
+    /// # let tree: SyntaxNode<MyLanguage> = SyntaxNode::new_root(builder.finish().0);
+    /// let plus = tree
+    ///     .children_with_tokens()
+    ///     .nth(2) // `x`, then a space, then `+`
+    ///     .unwrap()
+    ///     .into_token()
+    ///     .unwrap();
     /// assert_eq!(plus.static_text(), Some("+"));
     /// ```
     #[inline(always)]
@@ -254,59 +228,29 @@ impl<L: Language, D> SyntaxToken<L, D> {
     ///  
     /// # Examples
     /// ```
-    /// # use cstree::*;
-    /// # #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    /// # #[repr(u16)]
-    /// # enum SyntaxKind {
-    /// #     ROOT,
-    /// #     IDENT,
-    /// #     INT,
-    /// #     OP,
-    /// #     WS,
-    /// # }
-    /// # use SyntaxKind::*;
-    /// # #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    /// # enum Lang {}
-    /// # impl cstree::Language for Lang {
-    /// #     type Kind = SyntaxKind;
-    /// #
-    /// #     fn kind_from_raw(raw: cstree::SyntaxKind) -> Self::Kind {
-    /// #         assert!(raw.0 <= SyntaxKind::WS as u16);
-    /// #         unsafe { std::mem::transmute::<u16, SyntaxKind>(raw.0) }
-    /// #     }
-    /// #
-    /// #     fn kind_to_raw(kind: Self::Kind) -> cstree::SyntaxKind {
-    /// #         cstree::SyntaxKind(kind as u16)
-    /// #     }
-    /// #
-    /// #     fn static_text(kind: Self::Kind) -> Option<&'static str> {
-    /// #         match kind {
-    /// #             OP => Some("+"),
-    /// #             _ => None,
-    /// #         }
-    /// #     }
-    /// # }
-    /// # type SyntaxNode<L> = cstree::SyntaxNode<L, ()>;
-    /// # fn parse(b: &mut GreenNodeBuilder<Rodeo>, s: &str) {}
-    /// #
-    /// let mut builder = GreenNodeBuilder::new();
-    /// # builder.start_node(ROOT);
-    /// # builder.token_with_text(IDENT, "x");
-    /// # builder.token_with_text(WS, " ");
-    /// # builder.token(OP);
-    /// # builder.token_with_text(WS, " ");
-    /// # builder.token_with_text(IDENT, "x");
-    /// # builder.token_with_text(WS, " ");
-    /// # builder.token(OP);
-    /// # builder.token_with_text(INT, "3");
+    /// # use cstree::doctest::*;
+    /// let mut builder: GreenNodeBuilder<MyLanguage> = GreenNodeBuilder::new();
+    /// # builder.start_node(Root);
+    /// # builder.token(Identifier, "x");
+    /// # builder.token(Whitespace, " ");
+    /// # builder.token(Plus, "+");
+    /// # builder.token(Whitespace, " ");
+    /// # builder.token(Identifier, "x");
+    /// # builder.token(Whitespace, " ");
+    /// # builder.token(Plus, "+");
+    /// # builder.token(Int, "3");
     /// # builder.finish_node();
-    /// # let tree = SyntaxNode::<Lang>::new_root(builder.finish().0);
     /// let tree = parse(&mut builder, "x + x + 3");
-    /// let first_x = tree.children_with_tokens().next().unwrap().into_token().unwrap();
-    /// let second_x = tree.children_with_tokens().nth(4).unwrap().into_token().unwrap();
+    /// # let tree: SyntaxNode<MyLanguage> = SyntaxNode::new_root(builder.finish().0);
+    /// let mut tokens = tree.children_with_tokens();
+    /// let tokens = tokens.by_ref();
+    /// let first_x = tokens.next().unwrap().into_token().unwrap();
+    ///
+    /// // For the other tokens, skip over the whitespace between them
+    /// let first_plus = tokens.skip(1).next().unwrap().into_token().unwrap();
+    /// let second_x = tokens.skip(1).next().unwrap().into_token().unwrap();
+    /// let second_plus = tokens.skip(1).next().unwrap().into_token().unwrap();
     /// assert!(first_x.text_eq(&second_x));
-    /// let first_plus = tree.children_with_tokens().nth(2).unwrap().into_token().unwrap();
-    /// let second_plus = tree.children_with_tokens().nth(6).unwrap().into_token().unwrap();
     /// assert!(first_plus.text_eq(&second_plus));
     /// ```
     #[inline]
@@ -329,37 +273,12 @@ impl<L: Language, D> SyntaxToken<L, D> {
     /// See also [`resolve_text`](SyntaxToken::resolve_text) and [`text_eq`](SyntaxToken::text_eq).
     ///
     /// # Examples
-    /// If you intern strings inside of your application, e.g. inside of a compiler, you can use
+    /// If you intern strings inside of your application, like inside a compiler, you can use
     /// token's text keys to cross-reference between the syntax tree and the rest of your
     /// implementation by re-using the interner in both.
     /// ```
-    /// # use cstree::*;
-    /// # use cstree::interning::{Hasher, Rodeo, Key, new_interner};
-    /// # #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    /// # #[repr(u16)]
-    /// # enum SyntaxKind {
-    /// #     ROOT,
-    /// #     INT,
-    /// # }
-    /// # #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    /// # enum Lang {}
-    /// # impl cstree::Language for Lang {
-    /// #     type Kind = SyntaxKind;
-    /// #
-    /// #     fn kind_from_raw(raw: cstree::SyntaxKind) -> Self::Kind {
-    /// #         assert!(raw.0 <= SyntaxKind::INT as u16);
-    /// #         unsafe { std::mem::transmute::<u16, SyntaxKind>(raw.0) }
-    /// #     }
-    /// #
-    /// #     fn kind_to_raw(kind: Self::Kind) -> cstree::SyntaxKind {
-    /// #         cstree::SyntaxKind(kind as u16)
-    /// #     }
-    /// # }
-    /// # type SyntaxNode<L> = cstree::SyntaxNode<L, ()>;
-    /// # const ROOT:  cstree::SyntaxKind = cstree::SyntaxKind(0);
-    /// # const IDENT: cstree::SyntaxKind = cstree::SyntaxKind(1);
-    /// # fn parse(b: &mut GreenNodeBuilder<Rodeo>, s: &str) {}
-    /// #
+    /// # use cstree::doctest::*;
+    /// use cstree::interning::{new_interner, Hasher, Key, Rodeo};
     /// struct TypeTable {
     ///     // ...
     /// }
@@ -373,17 +292,26 @@ impl<L: Language, D> SyntaxToken<L, D> {
     /// #   interner: Rodeo,
     /// #   type_table: TypeTable,
     /// # }
-    /// # let interner = new_interner();
-    /// # let state = &mut State { interner, type_table: TypeTable{} };
-    /// let mut builder = GreenNodeBuilder::with_interner(&mut state.interner);
+    /// let interner = new_interner();
+    /// let mut state = State {
+    ///     interner,
+    ///     type_table: TypeTable{ /* stuff */},
+    /// };
+    /// let mut builder: GreenNodeBuilder<MyLanguage, Rodeo> =
+    ///     GreenNodeBuilder::with_interner(&mut state.interner);
     /// # let input = "";
-    /// # builder.start_node(ROOT);
-    /// # builder.token_with_text(IDENT, "x");
+    /// # builder.start_node(Root);
+    /// # builder.token(Identifier, "x");
     /// # builder.finish_node();
     /// let tree = parse(&mut builder, "x");
-    /// # let tree = SyntaxNode::<Lang>::new_root(builder.finish().0);
+    /// # let tree: SyntaxNode<MyLanguage> = SyntaxNode::new_root(builder.finish().0);
     /// let type_table = &state.type_table;
-    /// let ident = tree.children_with_tokens().next().unwrap().into_token().unwrap();
+    /// let ident = tree
+    ///     .children_with_tokens()
+    ///     .next()
+    ///     .unwrap()
+    ///     .into_token()
+    ///     .unwrap();
     /// let typ = type_table.type_of(ident.text_key().unwrap());
     /// ```
     #[inline]

--- a/src/utility_types.rs
+++ b/src/utility_types.rs
@@ -88,6 +88,47 @@ impl<T> WalkEvent<T> {
     }
 }
 
+#[derive(Debug)]
+pub(crate) enum MaybeOwned<'a, T> {
+    Owned(T),
+    Borrowed(&'a mut T),
+}
+
+impl<T> MaybeOwned<'_, T> {
+    pub(crate) fn into_owned(self) -> Option<T> {
+        match self {
+            MaybeOwned::Owned(owned) => Some(owned),
+            MaybeOwned::Borrowed(_) => None,
+        }
+    }
+}
+
+impl<T> std::ops::Deref for MaybeOwned<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        match self {
+            MaybeOwned::Owned(it) => it,
+            MaybeOwned::Borrowed(it) => *it,
+        }
+    }
+}
+
+impl<T> std::ops::DerefMut for MaybeOwned<'_, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        match self {
+            MaybeOwned::Owned(it) => it,
+            MaybeOwned::Borrowed(it) => *it,
+        }
+    }
+}
+
+impl<T: Default> Default for MaybeOwned<'_, T> {
+    fn default() -> Self {
+        MaybeOwned::Owned(T::default())
+    }
+}
+
 /// There might be zero, one or two leaves at a given offset.
 #[derive(Clone, Debug)]
 pub enum TokenAtOffset<T> {

--- a/tests/it/basic.rs
+++ b/tests/it/basic.rs
@@ -3,7 +3,7 @@ use cstree::{GreenNodeBuilder, NodeCache, SyntaxKind, TextRange};
 use lasso::{Resolver, Rodeo};
 
 fn build_tree<D>(root: &Element<'_>) -> (SyntaxNode<D>, impl Resolver) {
-    let mut builder = GreenNodeBuilder::new();
+    let mut builder: GreenNodeBuilder<TestLang> = GreenNodeBuilder::new();
     build_recursive(root, &mut builder, 0);
     let (node, cache) = builder.finish();
     (SyntaxNode::new_root(node), cache.unwrap().into_interner().unwrap())
@@ -178,5 +178,5 @@ fn assert_debug_display() {
     f::<cstree::NodeOrToken<String, u128>>();
 
     fn dbg<T: fmt::Debug>() {}
-    dbg::<GreenNodeBuilder<'static, 'static>>();
+    dbg::<GreenNodeBuilder<'static, 'static, TestLang>>();
 }

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -35,21 +35,30 @@ impl Language for TestLang {
     fn kind_to_raw(kind: Self::Kind) -> SyntaxKind {
         kind
     }
+
+    fn static_text(kind: Self::Kind) -> Option<&'static str> {
+        None
+    }
 }
 
 pub fn build_tree_with_cache<'c, 'i, I>(root: &Element<'_>, cache: &'c mut NodeCache<'i, I>) -> GreenNode
 where
     I: Interner,
 {
-    let mut builder = GreenNodeBuilder::with_cache(cache);
+    let mut builder: GreenNodeBuilder<TestLang, I> = GreenNodeBuilder::with_cache(cache);
     build_recursive(root, &mut builder, 0);
     let (node, cache) = builder.finish();
     assert!(cache.is_none());
     node
 }
 
-pub fn build_recursive<'c, 'i, I>(root: &Element<'_>, builder: &mut GreenNodeBuilder<'c, 'i, I>, mut from: u16) -> u16
+pub fn build_recursive<'c, 'i, L, I>(
+    root: &Element<'_>,
+    builder: &mut GreenNodeBuilder<'c, 'i, L, I>,
+    mut from: u16,
+) -> u16
 where
+    L: Language<Kind = SyntaxKind>,
     I: Interner,
 {
     match root {
@@ -61,7 +70,7 @@ where
             builder.finish_node();
         }
         Element::Token(text) => {
-            builder.token(SyntaxKind(from), *text);
+            builder.token_with_text(SyntaxKind(from), *text);
         }
     }
     from

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -36,7 +36,7 @@ impl Language for TestLang {
         kind
     }
 
-    fn static_text(kind: Self::Kind) -> Option<&'static str> {
+    fn static_text(_kind: Self::Kind) -> Option<&'static str> {
         None
     }
 }
@@ -70,7 +70,7 @@ where
             builder.finish_node();
         }
         Element::Token(text) => {
-            builder.token_with_text(SyntaxKind(from), *text);
+            builder.token(SyntaxKind(from), *text);
         }
     }
     from

--- a/tests/it/regressions.rs
+++ b/tests/it/regressions.rs
@@ -25,7 +25,7 @@ fn empty_tree_arc() {
             cstree::SyntaxKind(kind as u16)
         }
 
-        fn static_text(kind: Self::Kind) -> Option<&'static str> {
+        fn static_text(_kind: Self::Kind) -> Option<&'static str> {
             None
         }
     }

--- a/tests/it/regressions.rs
+++ b/tests/it/regressions.rs
@@ -24,9 +24,13 @@ fn empty_tree_arc() {
         fn kind_to_raw(kind: Self::Kind) -> cstree::SyntaxKind {
             cstree::SyntaxKind(kind as u16)
         }
+
+        fn static_text(kind: Self::Kind) -> Option<&'static str> {
+            None
+        }
     }
-    let mut builder = GreenNodeBuilder::new();
-    builder.start_node(SyntaxKind(0));
+    let mut builder: GreenNodeBuilder<Lang> = GreenNodeBuilder::new();
+    builder.start_node(SyntaxKind::Root);
     builder.finish_node();
     let (green, _) = builder.finish();
     let root: SyntaxNode<Lang> = SyntaxNode::new_root(green);

--- a/tests/it/sendsync.rs
+++ b/tests/it/sendsync.rs
@@ -3,11 +3,11 @@
 use crossbeam_utils::thread::scope;
 use std::{thread, time::Duration};
 
-use super::{build_recursive, Element, ResolvedNode, SyntaxNode};
+use super::{build_recursive, Element, ResolvedNode, SyntaxNode, TestLang};
 use cstree::{interning::IntoResolver, GreenNodeBuilder};
 
 fn build_tree<D>(root: &Element<'_>) -> ResolvedNode<D> {
-    let mut builder = GreenNodeBuilder::new();
+    let mut builder: GreenNodeBuilder<TestLang> = GreenNodeBuilder::new();
     build_recursive(root, &mut builder, 0);
     let (node, cache) = builder.finish();
     SyntaxNode::new_root_with_resolver(node, cache.unwrap().into_interner().unwrap().into_resolver())

--- a/tests/it/serde.rs
+++ b/tests/it/serde.rs
@@ -1,6 +1,6 @@
 use crate::{build_recursive, build_tree_with_cache, ResolvedNode};
 
-use super::{Element, SyntaxNode};
+use super::{Element, SyntaxNode, TestLang};
 use cstree::{
     interning::{new_interner, IntoResolver},
     GreenNodeBuilder, NodeCache, NodeOrToken,
@@ -224,7 +224,7 @@ fn three_level_tree() -> Element<'static> {
 }
 
 fn build_tree(root: Element<'_>) -> ResolvedNode<String> {
-    let mut builder = GreenNodeBuilder::new();
+    let mut builder: GreenNodeBuilder<TestLang> = GreenNodeBuilder::new();
     build_recursive(&root, &mut builder, 0);
     let (node, cache) = builder.finish();
     SyntaxNode::new_root_with_resolver(node, cache.unwrap().into_interner().unwrap().into_resolver())


### PR DESCRIPTION
Cracking down on tree building time in particular by
 * providing a new method `Language::static_text` to declare syntax kinds that only have one possible source text and optimizing for it by not interning (and importantly not even checking if it is already interned) the source text for tokens of these kinds
 * avoiding some unnecessary cloning and dropping of `ThinArc`s in `GreenNodeBuilder::finish_node`

Additionally, the internal representation of `SyntaxNode` is updated from `*mut NodeData<L, D>` to `NonNull<NodeData<L, D>>`, which was actually already guaranteed to hold since the pointer comes from `Box::into_raw`, to benefit from niche optimization. A test case the validates this is added.

Further, adds a CHANGELOG to keep track of these changes.

Closes #42. 