### PR TITLE
Update CI workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,11 +61,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: hecrj/setup-rust-action@v1
         with:
-          profile: minimal
-          toolchain: nightly
-          override: true
+          rust-version: nightly
 
       - uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,29 +28,25 @@ jobs:
         rust: [stable, nightly]
 
     steps:
+      # setup
       - uses: actions/checkout@v3
       - uses: hecrj/setup-rust-action@v1
         with:
           rust-version: ${{ matrix.rust }}
       - uses: taiki-e/install-action@nextest
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: nextest
-          args: run --profile ci-default-features --tests --examples --verbose
-      - uses: actions-rs/cargo@v1
-        with:
-          command: nextest
-          args: run --profile ci-all-features --tests --examples --verbose --all-features
-      - uses: actions-rs/cargo@v1
-        with:
-          command: nextest
-          args: run --profile ci-all-features-release --tests --examples --verbose --all-features --release
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --doc --verbose --all-features
-      - uses: actions/upload-artifact@v3  # upload test results
+      # tests
+      - name: Library Tests | Default Features
+        run: cargo nextest run --profile ci-default-features --tests --examples --verbose
+      - name: Library Tests | All Features
+        run: cargo nextest run --profile ci-all-features --tests --examples --verbose --all-features
+      - name: Library Tests | All Features (Release)
+        run: cargo nextest run --profile ci-all-features --tests --examples --verbose --all-features --release
+      - name: Doc Tests 
+        run: cargo test --doc --verbose --all-features
+
+      # upload test results
+      - uses: actions/upload-artifact@v3  
         if: success() || failure()        # run this step even if previous step failed
         with:
           name: test-results-${{ matrix.rust }}-${{ matrix.os }}
@@ -64,11 +60,8 @@ jobs:
       - uses: hecrj/setup-rust-action@v1
         with:
           rust-version: nightly
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --all-targets --all-features
+      - name: Cargo Check
+        run: cargo check --all-targets --all-features
 
   clippy:
     name: Clippy

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           command: test
           args: --doc --verbose --all-features
-      - uses: actions/upload-artifact@v2  # upload test results
+      - uses: actions/upload-artifact@v3  # upload test results
         if: success() || failure()        # run this step even if previous step failed
         with:
           name: test-results-${{ matrix.rust }}-${{ matrix.os }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -80,7 +80,7 @@ jobs:
       RUSTFLAGS: -Dwarnings
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: hecrj/setup-rust-action@v1
         with:
           components: clippy
@@ -91,7 +91,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: hecrj/setup-rust-action@v1
         with:
           rust-version: nightly
@@ -105,7 +105,7 @@ jobs:
       RUSTDOCFLAGS: -Dwarnings --cfg doc_cfg
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: hecrj/setup-rust-action@v1
         with:
           rust-version: nightly
@@ -121,7 +121,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: hecrj/setup-rust-action@v1
         with:
           rust-version: nightly
@@ -138,7 +138,7 @@ jobs:
       matrix:
         sanitizer: [address, memory, thread, leak]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: hecrj/setup-rust-action@v1
         with:
           rust-version: nightly

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Library Tests | All Features
         run: cargo nextest run --profile ci-all-features --tests --examples --verbose --all-features
       - name: Library Tests | All Features (Release)
-        run: cargo nextest run --profile ci-all-features --tests --examples --verbose --all-features --release
+        run: cargo nextest run --profile ci-all-features-release --tests --examples --verbose --all-features --release
       - name: Doc Tests 
         run: cargo test --doc --verbose --all-features
 

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -11,6 +11,6 @@ jobs:
     - uses: dorny/test-reporter@v1
       with:
         artifact: /test-results-([a-z]*)-(.*)/ # artifact name: test-results-<toolchain>-<os>
-        name: cargo nextest results $1 $2      # Name of the check run which will be created
+        name: Results | $1 $2      # Name of the check run which will be created
         path: './**/junit-*.xml'               # Path to test results (inside artifact .zip)
         reporter: java-junit                   # Format of test results


### PR DESCRIPTION
Update workflows to use the latest version of any used actions and replace deprecated / unmaintained actions (in particular, `actions-rs`) with either alternative actions or direct workflow commands (`run`).