### PR TITLE
Prepare release candidate for publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ authors = [
     "Domenic Quirl <DomenicQuirl@pm.me>",
     "Aleksey Kladov <aleksey.kladov@gmail.com>",
 ]
-description = "Library for generic lossless syntax trees"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/domenicquirl/cstree"
 readme = "README.md"

--- a/cstree-derive/Cargo.toml
+++ b/cstree-derive/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name                   = "cstree_derive"
+description            = "Macro implementation of `#[derive(Syntax)]`"
+keywords               = ["cstree", "derive"]
 edition.workspace      = true
 version.workspace      = true
 authors.workspace      = true

--- a/cstree/Cargo.toml
+++ b/cstree/Cargo.toml
@@ -29,7 +29,7 @@ version  = "0.12.0-rc.0"      # must match the `cstree` version in the virtual w
 optional = true
 
 [dependencies.lasso]
-version  = "0.6"
+version  = "0.7"
 features = ["inline-more"]
 optional = true
 

--- a/cstree/Cargo.toml
+++ b/cstree/Cargo.toml
@@ -33,11 +33,11 @@ version  = "0.7"
 features = ["inline-more"]
 optional = true
 
-[dependencies.salsa]
-git      = "https://github.com/salsa-rs/salsa/"
-version  = "0.1"
-optional = true
-package  = "salsa-2022"
+# [dependencies.salsa]
+# git      = "https://github.com/salsa-rs/salsa/"
+# version  = "0.1"
+# optional = true
+# package  = "salsa-2022"
 
 [dependencies.serde]
 version          = "1.0"
@@ -72,7 +72,15 @@ multi_threaded_interning = ["lasso_compat", "lasso/multi-threaded"]
 # Interoperability with the `salsa` framework for incremental computation.
 # Use this feature for "Salsa 2022".
 # WARNING: This feature is considered unstable!
-salsa_2022_compat = ["salsa"]
+# salsa_2022_compat = ["salsa"]
+
+[[example]]
+name              = "math"
+required-features = ["derive"]
+
+[[example]]
+name              = "s_expressions"
+required-features = ["derive"]
 
 [[example]]
 name              = "salsa"

--- a/cstree/Cargo.toml
+++ b/cstree/Cargo.toml
@@ -1,5 +1,8 @@
 [package]
 name                   = "cstree"
+description            = "Library for generic lossless syntax trees"
+categories             = ["parsing", "data-structures"]
+keywords               = ["cstree", "parser", "parsing", "cst"]
 edition.workspace      = true
 version.workspace      = true
 authors.workspace      = true

--- a/cstree/src/interning.rs
+++ b/cstree/src/interning.rs
@@ -53,12 +53,12 @@
 //! implementation to make `lasso`'s interners work with `cstree` (as well as a re-export of the matching version of
 //! `lasso` here). If enabled, `cstree`'s built-in interning functionality is replaced with `lasso`'s more efficient one
 //! transparently, so you'll now be returned a `lasso` interner from [`new_interner`].
-//!
-//! ### `salsa`
-//! If you are using the "2022" version of the `salsa` incremental query framework, it is possible to use its interning
-//! capabilities with `cstree` as well. Support for this is experimental, and you have to opt in via the
-//! `salsa_2022_compat` feature. For instructions on how to do this, and whether you actually want to, please refer to
-//! [the `salsa_compat` module documentation].
+//
+// ### `salsa`
+// If you are using the "2022" version of the `salsa` incremental query framework, it is possible to use its interning
+// capabilities with `cstree` as well. Support for this is experimental, and you have to opt in via the
+// `salsa_2022_compat` feature. For instructions on how to do this, and whether you actually want to, please refer to
+// [the `salsa_compat` module documentation].
 #![cfg_attr(
     feature = "multi_threaded_interning",
     doc = r###"
@@ -104,7 +104,7 @@ of the `GreenNodeBuilder` appropriately.
 //! [`NodeCache::into_interner`]: crate::build::NodeCache::into_interner
 //! [`SyntaxNode::new_root_with_resolver`]: crate::syntax::SyntaxNode::new_root_with_resolver
 //! [`lasso`]: lasso
-//! [the `salsa_compat` module documentation]: salsa_compat
+// [the `salsa_compat` module documentation]: salsa_compat
 
 mod traits;
 pub use self::traits::*;


### PR DESCRIPTION
 * [update `Cargo.toml`s with descriptions, keywords and categories](https://github.com/domenicquirl/cstree/commit/5f99b331d46aa2ec59c46a9269c88bb98aa69f72)
 * [bump `lasso` to version 0.7](https://github.com/domenicquirl/cstree/commit/860f1cd53a4a42903be584a1462371365b8cbcf7)
 * [disable experimental support for `salsa` 2022](https://github.com/domenicquirl/cstree/commit/c35a62cc15111cdedec37cff8fc7671d7390230a) as there is no published version available to depend on