### PR TITLE
Feature gate `triomphe/serde` behind `cstree/serialize`

### DIFF
--- a/cstree/Cargo.toml
+++ b/cstree/Cargo.toml
@@ -17,7 +17,7 @@ fxhash      = "0.2.1"
 parking_lot = "0.12.1"
 
 # Arc
-triomphe = "0.1.7"
+triomphe = { version = "0.1.7", default-features = false, features = ["stable_deref_trait", "std"] }
 sptr     = "0.3.2"
 
 # Default Interner
@@ -61,7 +61,7 @@ default = []
 # Derive macro for `Syntax`
 derive = ["dep:cstree_derive"]
 # Implementations of `serde::{De,}Serialize` for CSTrees.
-serialize = ["serde", "lasso?/serialize"]
+serialize = ["serde", "lasso?/serialize", "triomphe/serde"]
 # Interoperability with the `lasso` interning crate.
 # When enabled, `cstree`'s default interners will use `lasso` internally, too.
 lasso_compat = ["lasso"]


### PR DESCRIPTION
Currently, `cstree` pulls in `serde` even without the `serialize` feature. This is because `triomphe` has its `serde` feature enabled by default.

If this is unintentional, this PR removes `serde` from the dependency tree by feature-gating `triomphe/serde` behind `cstree/serialize`, so that it is only pulled in if the CSTs need to be serialized. This could be beneficial since `serde` adds extra compile time and binary size.