### PR TITLE
Clean up redundant doc links

### DIFF
--- a/cstree/src/interning.rs
+++ b/cstree/src/interning.rs
@@ -167,7 +167,7 @@ impl fmt::Debug for TokenKey {
     }
 }
 
-/// Constructs a new, single-threaded [`Interner`](traits::Interner).
+/// Constructs a new, single-threaded [`Interner`].
 ///
 /// If you need the interner to be multi-threaded, see [`new_threaded_interner`].
 #[inline]
@@ -175,7 +175,7 @@ pub fn new_interner() -> TokenInterner {
     TokenInterner::new()
 }
 
-/// Constructs a new [`Interner`](traits::Interner) that can be used across multiple threads.
+/// Constructs a new [`Interner`] that can be used across multiple threads.
 ///
 /// Note that you can use `&MultiThreadTokenInterner` to access interning methods through a shared reference, as well as
 /// construct new syntax trees. See [the module documentation](self) for more information and examples.

--- a/cstree/src/syntax/node.rs
+++ b/cstree/src/syntax/node.rs
@@ -117,15 +117,15 @@ impl<S: Syntax, D> SyntaxNode<S, D> {
         }
     }
 
-    /// Turns this node into a [`ResolvedNode`](crate::syntax::ResolvedNode), but only if there is a resolver associated
-    /// with this tree.
+    /// Turns this node into a [`ResolvedNode`], but only if there is a resolver associated with
+    /// this tree.
     #[inline]
     pub fn try_resolved(&self) -> Option<&ResolvedNode<S, D>> {
         // safety: we only coerce if `resolver` exists
         self.resolver().map(|_| unsafe { ResolvedNode::coerce_ref(self) })
     }
 
-    /// Turns this node into a [`ResolvedNode`](crate::syntax::ResolvedNode).
+    /// Turns this node into a [`ResolvedNode`].
     /// # Panics
     /// If there is no resolver associated with this tree.
     #[inline]

--- a/cstree/src/syntax/resolved.rs
+++ b/cstree/src/syntax/resolved.rs
@@ -111,8 +111,8 @@ impl<S: Syntax, D> DerefMut for ResolvedToken<S, D> {
 
 /// An element of the tree that is guaranteed to belong to a tree that contains an associated
 /// [`Resolver`](lasso::Resolver), can be either a node or a token.
-/// # See also
-/// [`SyntaxElement`](crate::syntax::SyntaxElement)
+///
+/// See also [`SyntaxElement`].
 pub type ResolvedElement<S, D = ()> = NodeOrToken<ResolvedNode<S, D>, ResolvedToken<S, D>>;
 
 impl<S: Syntax, D> From<ResolvedNode<S, D>> for ResolvedElement<S, D> {

--- a/cstree/src/syntax/token.rs
+++ b/cstree/src/syntax/token.rs
@@ -110,7 +110,7 @@ impl<S: Syntax, D> SyntaxToken<S, D> {
         self.parent.resolver()
     }
 
-    /// Turns this token into a [`ResolvedToken`](crate::syntax::ResolvedToken), but only if there is a resolver
+    /// Turns this token into a [`ResolvedToken`], but only if there is a resolver
     /// associated with this tree.
     #[inline]
     pub fn try_resolved(&self) -> Option<&ResolvedToken<S, D>> {
@@ -118,7 +118,7 @@ impl<S: Syntax, D> SyntaxToken<S, D> {
         self.resolver().map(|_| unsafe { ResolvedToken::coerce_ref(self) })
     }
 
-    /// Turns this token into a [`ResolvedToken`](crate::syntax::ResolvedToken).
+    /// Turns this token into a [`ResolvedToken`].
     /// # Panics
     /// If there is no resolver associated with this tree.
     #[inline]


### PR DESCRIPTION
that produce warnings in newer nightly versions.