### PR TITLE
Migrate to stable strict provenance APIs and elide some redundant lifetimes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ authors = [
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/domenicquirl/cstree"
 readme = "README.md"
-rust-version = "1.71"
+rust-version = "1.84"
 
 [profile.release]
 debug = true

--- a/cstree-derive/src/symbols.rs
+++ b/cstree-derive/src/symbols.rs
@@ -20,7 +20,7 @@ impl PartialEq<Symbol> for Ident {
     }
 }
 
-impl<'a> PartialEq<Symbol> for &'a Ident {
+impl PartialEq<Symbol> for &Ident {
     fn eq(&self, word: &Symbol) -> bool {
         *self == word.0
     }
@@ -32,7 +32,7 @@ impl PartialEq<Symbol> for Path {
     }
 }
 
-impl<'a> PartialEq<Symbol> for &'a Path {
+impl PartialEq<Symbol> for &Path {
     fn eq(&self, word: &Symbol) -> bool {
         self.is_ident(word.0)
     }

--- a/cstree/Cargo.toml
+++ b/cstree/Cargo.toml
@@ -18,7 +18,6 @@ parking_lot = "0.12.1"
 
 # Arc
 triomphe = { version = "0.1.8", default-features = false, features = ["stable_deref_trait", "std"] }
-sptr     = "0.3.2"
 
 # Default Interner
 indexmap = "2.4.0"

--- a/cstree/src/green/element.rs
+++ b/cstree/src/green/element.rs
@@ -4,8 +4,6 @@ use std::{fmt, hash, mem};
 // This MUST be size=1 such that pointer math actually advances the pointer.
 type ErasedPtr = *const u8;
 
-use sptr::Strict;
-
 use crate::{
     green::{GreenNode, GreenToken},
     text::TextSize,

--- a/cstree/src/green/iter.rs
+++ b/cstree/src/green/iter.rs
@@ -65,7 +65,7 @@ impl<'a> Iterator for GreenNodeChildren<'a> {
     }
 }
 
-impl<'a> DoubleEndedIterator for GreenNodeChildren<'a> {
+impl DoubleEndedIterator for GreenNodeChildren<'_> {
     #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {
         self.inner.next_back().map(PackedGreenElement::as_ref)

--- a/cstree/src/green/token.rs
+++ b/cstree/src/green/token.rs
@@ -5,7 +5,6 @@ use crate::{
     text::TextSize,
     RawSyntaxKind,
 };
-use sptr::Strict;
 use triomphe::Arc;
 
 #[repr(align(2))] // to use 1 bit for pointer tagging. NB: this is an at-least annotation

--- a/cstree/src/syntax/element.rs
+++ b/cstree/src/syntax/element.rs
@@ -103,7 +103,7 @@ impl<'a, S: Syntax, D> From<&'a SyntaxElement<S, D>> for SyntaxElementRef<'a, S,
     }
 }
 
-impl<'a, S: Syntax, D> SyntaxElementRef<'a, S, D> {
+impl<S: Syntax, D> SyntaxElementRef<'_, S, D> {
     /// Returns this element's [`Display`](fmt::Display) representation as a string.
     ///
     /// To avoid allocating for every element, see [`write_display`](type.SyntaxElementRef.html#method.write_display).

--- a/cstree/src/syntax/iter.rs
+++ b/cstree/src/syntax/iter.rs
@@ -57,13 +57,13 @@ impl<'n> Iterator for Iter<'n> {
     }
 }
 
-impl<'n> ExactSizeIterator for Iter<'n> {
+impl ExactSizeIterator for Iter<'_> {
     #[inline(always)]
     fn len(&self) -> usize {
         self.green.len()
     }
 }
-impl<'n> FusedIterator for Iter<'n> {}
+impl FusedIterator for Iter<'_> {}
 
 /// An iterator over the child nodes of a [`SyntaxNode`].
 #[derive(Clone, Debug)]
@@ -109,13 +109,13 @@ impl<'n, S: Syntax, D> Iterator for SyntaxNodeChildren<'n, S, D> {
     }
 }
 
-impl<'n, S: Syntax, D> ExactSizeIterator for SyntaxNodeChildren<'n, S, D> {
+impl<S: Syntax, D> ExactSizeIterator for SyntaxNodeChildren<'_, S, D> {
     #[inline(always)]
     fn len(&self) -> usize {
         self.inner.len()
     }
 }
-impl<'n, S: Syntax, D> FusedIterator for SyntaxNodeChildren<'n, S, D> {}
+impl<S: Syntax, D> FusedIterator for SyntaxNodeChildren<'_, S, D> {}
 
 /// An iterator over the children of a [`SyntaxNode`].
 #[derive(Clone, Debug)]
@@ -159,10 +159,10 @@ impl<'n, S: Syntax, D> Iterator for SyntaxElementChildren<'n, S, D> {
     }
 }
 
-impl<'n, S: Syntax, D> ExactSizeIterator for SyntaxElementChildren<'n, S, D> {
+impl<S: Syntax, D> ExactSizeIterator for SyntaxElementChildren<'_, S, D> {
     #[inline(always)]
     fn len(&self) -> usize {
         self.inner.len()
     }
 }
-impl<'n, S: Syntax, D> FusedIterator for SyntaxElementChildren<'n, S, D> {}
+impl<S: Syntax, D> FusedIterator for SyntaxElementChildren<'_, S, D> {}

--- a/cstree/src/syntax/text.rs
+++ b/cstree/src/syntax/text.rs
@@ -258,8 +258,8 @@ impl<I: Resolver<TokenKey> + ?Sized, S: Syntax, D> PartialEq<SyntaxText<'_, '_, 
     }
 }
 
-impl<'n1, 'i1, 'n2, 'i2, I1, I2, S1, S2, D1, D2> PartialEq<SyntaxText<'n2, 'i2, I2, S2, D2>>
-    for SyntaxText<'n1, 'i1, I1, S1, D1>
+impl<I1, I2, S1, S2, D1, D2> PartialEq<SyntaxText<'_, '_, I2, S2, D2>>
+    for SyntaxText<'_, '_, I1, S1, D1>
 where
     S1: Syntax,
     S2: Syntax,

--- a/cstree/src/syntax/text.rs
+++ b/cstree/src/syntax/text.rs
@@ -258,8 +258,7 @@ impl<I: Resolver<TokenKey> + ?Sized, S: Syntax, D> PartialEq<SyntaxText<'_, '_, 
     }
 }
 
-impl<I1, I2, S1, S2, D1, D2> PartialEq<SyntaxText<'_, '_, I2, S2, D2>>
-    for SyntaxText<'_, '_, I1, S1, D1>
+impl<I1, I2, S1, S2, D1, D2> PartialEq<SyntaxText<'_, '_, I2, S2, D2>> for SyntaxText<'_, '_, I1, S1, D1>
 where
     S1: Syntax,
     S2: Syntax,


### PR DESCRIPTION
This MR essentially does a Clippy pass over the code with Clippy from Rust 1.84.1. However, this includes the `sptr` imports now being marked as redundant because the provided polyfill trait for the strict provenance APIs is no longer used now that strict provenance including all functions used by `cstree` was stabilized in `std`/`core` in Rust 1.84.

I've decided to go ahead and make the swap, which will raise `cstree`'s MSRV to 1.84. This is of course very recent, but should less aggressive whenever the next version of `cstree` is actually released, which I presume to be past Feb. 20th, the release date of Rust 1.85 and the 2024 edition.

Aside from that, the changes are mostly eliding some lifetimes which the compiler can figure out by itself.