### PR TITLE
Implement Resolver and Interner for Arc<MultiThreadedTokenInterner>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
- * Implemented `Resolver` and `Interner` for `Arc<T>` where `T` implements either one of these traits.
+ * `&I` and `&mut I` will now implement `Resolver` if `I` implements `Resolver`.
+ * `&mut I` will now implement `Interner` if `I` implements `Interner`.
+ * Added an implementation for `Arc<MultiThreadedTokenInterner>` to implement `Resolver` and `Interner` so an `Arc` may be used alternatively to a reference to share access to the interner.
 
 ## `v0.12.2`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+ * Implemented `Resolver` and `Interner` for `Arc<T>` where `T` implements either one of these traits.
+
 ## `v0.12.2`
 
  * `Checkpoint`s for the `GreenNodeBuilder` can now be used across node boundaries, meaning you can use them to wrap (finished) nodes in addition to just tokens. 

--- a/cstree/src/interning.rs
+++ b/cstree/src/interning.rs
@@ -77,12 +77,15 @@ While the interning methods on [`Interner`] require a `&mut self` to also work f
 # use cstree::testing::*;
 # use cstree::interning::*;
 # use std::sync::Arc;
-let interner = new_threaded_interner();
+let interner = Arc::new(new_threaded_interner());
 let mut builder: GreenNodeBuilder<MySyntax, Arc<MultiThreadedTokenInterner>> =
-    GreenNodeBuilder::from_interner(Arc::clone(interner));
+    GreenNodeBuilder::from_interner(Arc::clone(&interner));
+
 // or:
+// let interner = new_threaded_interner();
 // let mut builder: GreenNodeBuilder<MySyntax, &MultiThreadedTokenInterner> =
 //     GreenNodeBuilder::from_interner(&interner);
+
 # builder.start_node(Root);
 # builder.token(Int, "42");
 # builder.finish_node();

--- a/cstree/src/interning/default_interner.rs
+++ b/cstree/src/interning/default_interner.rs
@@ -1,6 +1,7 @@
 #![cfg(not(feature = "lasso_compat"))]
 
 use core::fmt;
+use std::sync::Arc as StdArc;
 
 use fxhash::FxBuildHasher as Hasher;
 use indexmap::IndexSet;
@@ -37,6 +38,13 @@ impl fmt::Display for InternerError {
 impl std::error::Error for InternerError {}
 
 impl Resolver<TokenKey> for TokenInterner {
+    fn try_resolve(&self, key: TokenKey) -> Option<&str> {
+        let index = key.into_u32() as usize;
+        self.id_set.get_index(index).map(String::as_str)
+    }
+}
+
+impl Resolver<TokenKey> for StdArc<TokenInterner> {
     fn try_resolve(&self, key: TokenKey) -> Option<&str> {
         let index = key.into_u32() as usize;
         self.id_set.get_index(index).map(String::as_str)

--- a/cstree/src/interning/lasso_compat/token_interner.rs
+++ b/cstree/src/interning/lasso_compat/token_interner.rs
@@ -86,8 +86,8 @@ mod multi_threaded {
 
     /// A threadsafe [`Interner`] for deduplicating [`GreenToken`](crate::green::GreenToken) strings.
     ///
-    /// Note that [`Interner`] and [`Resolver`] are also implemented for `Arc<MultiThreadTokenInterner>` so you can pass
-    /// `&mut Arc::clone(interner)` in shared contexts.
+    /// Note that [`Interner`] and [`Resolver`] are also implemented for `&MultiThreadTokenInterner` and 
+    /// `Arc<MultiThreadTokenInterner>` so you can pass a mutable reference to either of these in shared contexts.
     #[cfg_attr(doc_cfg, doc(cfg(feature = "multi_threaded_interning")))]
     #[derive(Debug)]
     pub struct MultiThreadedTokenInterner {

--- a/cstree/src/interning/lasso_compat/token_interner.rs
+++ b/cstree/src/interning/lasso_compat/token_interner.rs
@@ -86,8 +86,8 @@ mod multi_threaded {
 
     /// A threadsafe [`Interner`] for deduplicating [`GreenToken`](crate::green::GreenToken) strings.
     ///
-    /// Note that [`Interner`] and [`Resolver`] are also implemented for  `&MultiThreadTokenInterner` so you can pass
-    /// `&mut &interner` in shared contexts.
+    /// Note that [`Interner`] and [`Resolver`] are also implemented for `Arc<MultiThreadTokenInterner>` so you can pass
+    /// `&mut Arc::clone(interner)` in shared contexts.
     #[cfg_attr(doc_cfg, doc(cfg(feature = "multi_threaded_interning")))]
     #[derive(Debug)]
     pub struct MultiThreadedTokenInterner {
@@ -106,7 +106,5 @@ mod multi_threaded {
     }
 
     impl_traits!(for MultiThreadedTokenInterner, if #[cfg(feature = "multi_threaded_interning")]);
-
-    impl_traits!(for &MultiThreadedTokenInterner, if #[cfg(feature = "multi_threaded_interning")]);
     impl_traits!(for StdArc<MultiThreadedTokenInterner>, if #[cfg(feature = "multi_threaded_interning")]);
 }

--- a/cstree/src/interning/lasso_compat/token_interner.rs
+++ b/cstree/src/interning/lasso_compat/token_interner.rs
@@ -86,7 +86,7 @@ mod multi_threaded {
 
     /// A threadsafe [`Interner`] for deduplicating [`GreenToken`](crate::green::GreenToken) strings.
     ///
-    /// Note that [`Interner`] and [`Resolver`] are also implemented for `&MultiThreadTokenInterner` and 
+    /// Note that [`Interner`] and [`Resolver`] are also implemented for `&MultiThreadTokenInterner` and
     /// `Arc<MultiThreadTokenInterner>` so you can pass a mutable reference to either of these in shared contexts.
     #[cfg_attr(doc_cfg, doc(cfg(feature = "multi_threaded_interning")))]
     #[derive(Debug)]

--- a/cstree/src/interning/lasso_compat/token_interner.rs
+++ b/cstree/src/interning/lasso_compat/token_interner.rs
@@ -82,6 +82,8 @@ pub use multi_threaded::MultiThreadedTokenInterner;
 mod multi_threaded {
     use super::*;
 
+    use std::sync::Arc as StdArc;
+
     /// A threadsafe [`Interner`] for deduplicating [`GreenToken`](crate::green::GreenToken) strings.
     ///
     /// Note that [`Interner`] and [`Resolver`] are also implemented for  `&MultiThreadTokenInterner` so you can pass
@@ -106,4 +108,5 @@ mod multi_threaded {
     impl_traits!(for MultiThreadedTokenInterner, if #[cfg(feature = "multi_threaded_interning")]);
 
     impl_traits!(for &MultiThreadedTokenInterner, if #[cfg(feature = "multi_threaded_interning")]);
+    impl_traits!(for StdArc<MultiThreadedTokenInterner>, if #[cfg(feature = "multi_threaded_interning")]);
 }

--- a/cstree/src/interning/lasso_compat/traits.rs
+++ b/cstree/src/interning/lasso_compat/traits.rs
@@ -120,23 +120,6 @@ mod multi_threaded {
     compat_interner!(ThreadedRodeo<K, S> where K: Hash, S: Clone if #[cfg(feature = "multi_threaded_interning")]);
 
     #[cfg_attr(doc_cfg, doc(cfg(feature = "multi_threaded_interning")))]
-    impl<K, S> Resolver<TokenKey> for &lasso::ThreadedRodeo<K, S>
-    where
-        K: lasso::Key + Hash,
-        S: BuildHasher + Clone,
-    {
-        #[inline]
-        fn try_resolve(&self, key: TokenKey) -> Option<&str> {
-            <lasso::ThreadedRodeo<K, S> as Resolver<TokenKey>>::try_resolve(self, key)
-        }
-
-        #[inline]
-        fn resolve(&self, key: TokenKey) -> &str {
-            <lasso::ThreadedRodeo<K, S> as Resolver<TokenKey>>::resolve(self, key)
-        }
-    }
-
-    #[cfg_attr(doc_cfg, doc(cfg(feature = "multi_threaded_interning")))]
     impl<K, S> Interner<TokenKey> for &lasso::ThreadedRodeo<K, S>
     where
         K: lasso::Key + Hash,

--- a/cstree/src/interning/traits.rs
+++ b/cstree/src/interning/traits.rs
@@ -64,7 +64,7 @@ impl<R: Resolver> Resolver for &mut R {
 /// **Note:** Because single-threaded interners may require mutable access, the methods on this trait take `&mut self`.
 /// In order to use a multi- (or single)-threaded interner that allows access through a shared reference, it is
 /// implemented for `&MultiThreadedTokenInterner` and `Arc<MultiThreadedTokenInterner>`, allowing it
-/// to be used with a `&mut &MultitThreadedTokenInterner` and `&mut Arc<MultiThreadTokenInterner>`.
+/// to be used with a `&mut &MultiThreadedTokenInterner` and `&mut Arc<MultiThreadTokenInterner>`.
 pub trait Interner<Key: InternKey = TokenKey>: Resolver<Key> {
     /// Represents possible ways in which interning may fail.
     /// For example, this might be running out of fresh intern keys, or failure to allocate sufficient space for a new

--- a/cstree/src/interning/traits.rs
+++ b/cstree/src/interning/traits.rs
@@ -38,13 +38,33 @@ pub trait Resolver<Key: InternKey = TokenKey> {
     }
 }
 
+impl<R: Resolver> Resolver for &R {
+    fn try_resolve(&self, key: TokenKey) -> Option<&str> {
+        (**self).try_resolve(key)
+    }
+
+    fn resolve(&self, key: TokenKey) -> &str {
+        (**self).resolve(key)
+    }
+}
+
+impl<R: Resolver> Resolver for &mut R {
+    fn try_resolve(&self, key: TokenKey) -> Option<&str> {
+        (**self).try_resolve(key)
+    }
+
+    fn resolve(&self, key: TokenKey) -> &str {
+        (**self).resolve(key)
+    }
+}
+
 /// A full interner, which can intern new strings returning intern keys and also resolve intern keys to the interned
 /// value.
 ///
 /// **Note:** Because single-threaded interners may require mutable access, the methods on this trait take `&mut self`.
 /// In order to use a multi- (or single)-threaded interner that allows access through a shared reference, it is
-/// implemented for `&`[`MultiThreadedTokenInterner`](crate::interning::MultiThreadedTokenInterner), allowing it to be
-/// used with a `&mut &MultiThreadTokenInterner`.
+/// implemented for `&MultiThreadedTokenInterner` and `Arc<MultiThreadedTokenInterner>`, allowing it
+/// to be used with a `&mut &MultitThreadedTokenInterner` and `&mut Arc<MultiThreadTokenInterner>`.
 pub trait Interner<Key: InternKey = TokenKey>: Resolver<Key> {
     /// Represents possible ways in which interning may fail.
     /// For example, this might be running out of fresh intern keys, or failure to allocate sufficient space for a new
@@ -63,5 +83,17 @@ pub trait Interner<Key: InternKey = TokenKey>: Resolver<Key> {
     fn get_or_intern(&mut self, text: &str) -> Key {
         self.try_get_or_intern(text)
             .unwrap_or_else(|_| panic!("failed to intern `{text:?}`"))
+    }
+}
+
+impl<I: Interner> Interner for &mut I {
+    type Error = I::Error;
+
+    fn try_get_or_intern(&mut self, text: &str) -> Result<TokenKey, Self::Error> {
+        (**self).try_get_or_intern(text)
+    }
+
+    fn get_or_intern(&mut self, text: &str) -> TokenKey {
+        (**self).get_or_intern(text)
     }
 }


### PR DESCRIPTION
This lets us share a single cache (`cstree::build::NodeCache<'static, Arc<cstree::interning::MultithreadedTokenInterner>>`) without lifetime issues. Notice the `'static`