### PR TITLE
use rustc_hash instead of fxhash

### DIFF
--- a/cstree/Cargo.toml
+++ b/cstree/Cargo.toml
@@ -13,7 +13,7 @@ rust-version.workspace = true
 
 [dependencies]
 text-size   = "1.1.0"
-fxhash      = "0.2.1"
+rustc-hash  = "2.1.1"
 parking_lot = "0.12.1"
 
 # Arc

--- a/cstree/src/green/builder.rs
+++ b/cstree/src/green/builder.rs
@@ -1,6 +1,6 @@
 use std::hash::{Hash, Hasher};
 
-use fxhash::{FxHashMap, FxHasher32};
+use rustc_hash::{FxHashMap, FxHasher};
 use text_size::TextSize;
 
 use crate::{
@@ -180,7 +180,7 @@ where
     fn node<S: Syntax>(&mut self, kind: S, all_children: &mut Vec<GreenElement>, offset: usize) -> GreenNode {
         // NOTE: this fn must remove all children starting at `first_child` from `all_children` before returning
         let kind = S::into_raw(kind);
-        let mut hasher = FxHasher32::default();
+        let mut hasher = FxHasher::default();
         let mut text_len: TextSize = 0.into();
         for child in &all_children[offset..] {
             text_len += child.text_len();

--- a/cstree/src/green/node.rs
+++ b/cstree/src/green/node.rs
@@ -3,7 +3,7 @@ use std::{
     slice,
 };
 
-use fxhash::FxHasher32;
+use rustc_hash::FxHasher;
 
 use crate::{
     green::{iter::GreenNodeChildren, GreenElement, PackedGreenElement},
@@ -41,7 +41,7 @@ impl GreenNode {
         I: IntoIterator<Item = GreenElement>,
         I::IntoIter: ExactSizeIterator,
     {
-        let mut hasher = FxHasher32::default();
+        let mut hasher = FxHasher::default();
         let mut text_len: TextSize = 0.into();
         let children = children
             .into_iter()

--- a/cstree/src/interning/default_interner.rs
+++ b/cstree/src/interning/default_interner.rs
@@ -2,15 +2,15 @@
 
 use core::fmt;
 
-use fxhash::FxBuildHasher as Hasher;
 use indexmap::IndexSet;
+use rustc_hash::FxBuildHasher;
 
 use super::{InternKey, Interner, Resolver, TokenKey};
 
 /// The default [`Interner`] used to deduplicate green token strings.
 #[derive(Debug)]
 pub struct TokenInterner {
-    id_set: IndexSet<String, Hasher>,
+    id_set: IndexSet<String, FxBuildHasher>,
 }
 
 impl TokenInterner {

--- a/cstree/src/interning/lasso_compat/token_interner.rs
+++ b/cstree/src/interning/lasso_compat/token_interner.rs
@@ -59,7 +59,7 @@ impl TokenInterner {
         Self {
             rodeo: Rodeo::with_capacity_and_hasher(
                 Capacity::new(DEFAULT_STRING_CAPACITY, DEFAULT_BYTE_CAPACITY),
-                FxBuildHasher::default(),
+                FxBuildHasher,
             ),
         }
     }

--- a/cstree/src/interning/lasso_compat/token_interner.rs
+++ b/cstree/src/interning/lasso_compat/token_interner.rs
@@ -2,7 +2,7 @@
 
 #![cfg(feature = "lasso_compat")]
 
-use std::{hash::BuildHasher, num::NonZeroUsize};
+use std::{fmt, hash::BuildHasher, num::NonZeroUsize};
 
 use lasso::{Capacity, Rodeo, ThreadedRodeo};
 use rustc_hash::FxBuildHasher;
@@ -50,7 +50,6 @@ macro_rules! impl_traits {
 }
 
 /// The default [`Interner`] used to deduplicate green token strings.
-#[derive(Debug)]
 pub struct TokenInterner {
     rodeo: Rodeo<TokenKey, FxBuildHasher>,
 }
@@ -73,6 +72,12 @@ impl TokenInterner {
     }
 }
 
+impl fmt::Debug for TokenInterner {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("TokenInterner")
+    }
+}
+
 impl_traits!(for TokenInterner);
 
 #[cfg(feature = "multi_threaded_interning")]
@@ -87,7 +92,6 @@ mod multi_threaded {
     /// Note that [`Interner`] and [`Resolver`] are also implemented for  `&MultiThreadTokenInterner` so you can pass
     /// `&mut &interner` in shared contexts.
     #[cfg_attr(doc_cfg, doc(cfg(feature = "multi_threaded_interning")))]
-    #[derive(Debug)]
     pub struct MultiThreadedTokenInterner {
         rodeo: ThreadedRodeo<TokenKey, FxBuildHasher>,
     }
@@ -100,6 +104,12 @@ mod multi_threaded {
                     FxBuildHasher::default(),
                 ),
             }
+        }
+    }
+
+    impl fmt::Debug for MultiThreadedTokenInterner {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str("MultiThreadedTokenInterner")
         }
     }
 

--- a/cstree/src/interning/lasso_compat/token_interner.rs
+++ b/cstree/src/interning/lasso_compat/token_interner.rs
@@ -4,8 +4,8 @@
 
 use std::{hash::BuildHasher, num::NonZeroUsize};
 
-use fxhash::FxBuildHasher as Hasher;
 use lasso::{Capacity, Rodeo, ThreadedRodeo};
+use rustc_hash::FxBuildHasher;
 
 use crate::interning::{Interner, Resolver, TokenKey};
 
@@ -52,7 +52,7 @@ macro_rules! impl_traits {
 /// The default [`Interner`] used to deduplicate green token strings.
 #[derive(Debug)]
 pub struct TokenInterner {
-    rodeo: Rodeo<TokenKey, Hasher>,
+    rodeo: Rodeo<TokenKey, FxBuildHasher>,
 }
 
 impl TokenInterner {
@@ -60,7 +60,7 @@ impl TokenInterner {
         Self {
             rodeo: Rodeo::with_capacity_and_hasher(
                 Capacity::new(DEFAULT_STRING_CAPACITY, DEFAULT_BYTE_CAPACITY),
-                Hasher::default(),
+                FxBuildHasher::default(),
             ),
         }
     }
@@ -89,7 +89,7 @@ mod multi_threaded {
     #[cfg_attr(doc_cfg, doc(cfg(feature = "multi_threaded_interning")))]
     #[derive(Debug)]
     pub struct MultiThreadedTokenInterner {
-        rodeo: ThreadedRodeo<TokenKey, Hasher>,
+        rodeo: ThreadedRodeo<TokenKey, FxBuildHasher>,
     }
 
     impl MultiThreadedTokenInterner {
@@ -97,7 +97,7 @@ mod multi_threaded {
             Self {
                 rodeo: ThreadedRodeo::with_capacity_and_hasher(
                     Capacity::new(DEFAULT_STRING_CAPACITY, DEFAULT_BYTE_CAPACITY),
-                    Hasher::default(),
+                    FxBuildHasher::default(),
                 ),
             }
         }

--- a/cstree/src/interning/lasso_compat/token_interner.rs
+++ b/cstree/src/interning/lasso_compat/token_interner.rs
@@ -101,7 +101,7 @@ mod multi_threaded {
             Self {
                 rodeo: ThreadedRodeo::with_capacity_and_hasher(
                     Capacity::new(DEFAULT_STRING_CAPACITY, DEFAULT_BYTE_CAPACITY),
-                    FxBuildHasher::default(),
+                    FxBuildHasher,
                 ),
             }
         }


### PR DESCRIPTION
also removed `use rustc_hash::FxHasher as Hasher`-like stuff as it may be confused with the std hash traits