### PR TITLE
Fix overly restrictive derive(Clone)s

### DIFF
--- a/cstree/src/syntax/iter.rs
+++ b/cstree/src/syntax/iter.rs
@@ -66,10 +66,19 @@ impl ExactSizeIterator for Iter<'_> {
 impl FusedIterator for Iter<'_> {}
 
 /// An iterator over the child nodes of a [`SyntaxNode`].
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct SyntaxNodeChildren<'n, S: Syntax, D: 'static = ()> {
     inner:  Iter<'n>,
     parent: &'n SyntaxNode<S, D>,
+}
+
+impl<S: Syntax, D> Clone for SyntaxNodeChildren<'_, S, D> {
+    fn clone(&self) -> Self {
+        Self {
+            inner:  self.inner.clone(),
+            parent: self.parent,
+        }
+    }
 }
 
 impl<'n, S: Syntax, D> SyntaxNodeChildren<'n, S, D> {
@@ -118,10 +127,19 @@ impl<S: Syntax, D> ExactSizeIterator for SyntaxNodeChildren<'_, S, D> {
 impl<S: Syntax, D> FusedIterator for SyntaxNodeChildren<'_, S, D> {}
 
 /// An iterator over the children of a [`SyntaxNode`].
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct SyntaxElementChildren<'n, S: Syntax, D: 'static = ()> {
     inner:  Iter<'n>,
     parent: &'n SyntaxNode<S, D>,
+}
+
+impl<S: Syntax, D> Clone for SyntaxElementChildren<'_, S, D> {
+    fn clone(&self) -> Self {
+        Self {
+            inner:  self.inner.clone(),
+            parent: self.parent,
+        }
+    }
 }
 
 impl<'n, S: Syntax, D> SyntaxElementChildren<'n, S, D> {
@@ -166,3 +184,35 @@ impl<S: Syntax, D> ExactSizeIterator for SyntaxElementChildren<'_, S, D> {
     }
 }
 impl<S: Syntax, D> FusedIterator for SyntaxElementChildren<'_, S, D> {}
+
+#[cfg(test)]
+#[allow(dead_code)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    struct DummyKind;
+
+    impl Syntax for DummyKind {
+        fn from_raw(_: crate::RawSyntaxKind) -> Self {
+            unreachable!()
+        }
+
+        fn into_raw(self) -> crate::RawSyntaxKind {
+            unreachable!()
+        }
+
+        fn static_text(self) -> Option<&'static str> {
+            unreachable!()
+        }
+    }
+
+    struct NotClone;
+
+    fn assert_clone<C: Clone>() {}
+
+    fn test_impls_clone() {
+        assert_clone::<SyntaxNodeChildren<DummyKind, NotClone>>();
+        assert_clone::<SyntaxElementChildren<DummyKind, NotClone>>();
+    }
+}

--- a/cstree/src/syntax/text.rs
+++ b/cstree/src/syntax/text.rs
@@ -40,12 +40,19 @@ use crate::{
 /// let sub = text.slice(2.into()..5.into());
 /// assert_eq!(sub, "748");
 /// ```
-#[derive(Clone)]
 pub struct SyntaxText<'n, 'i, I: ?Sized, S: Syntax, D: 'static = ()> {
     node:     &'n SyntaxNode<S, D>,
     range:    TextRange,
     resolver: &'i I,
 }
+
+impl<I: ?Sized, S: Syntax, D> Clone for SyntaxText<'_, '_, I, S, D> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<I: ?Sized, S: Syntax, D> Copy for SyntaxText<'_, '_, I, S, D> {}
 
 impl<'n, 'i, I: Resolver<TokenKey> + ?Sized, S: Syntax, D> SyntaxText<'n, 'i, I, S, D> {
     pub(crate) fn new(node: &'n SyntaxNode<S, D>, resolver: &'i I) -> Self {
@@ -378,7 +385,7 @@ mod private {
 
 #[cfg(test)]
 mod tests {
-    use crate::{build::GreenNodeBuilder, RawSyntaxKind};
+    use crate::{build::GreenNodeBuilder, interning::TokenInterner, RawSyntaxKind};
 
     use super::*;
 
@@ -449,5 +456,18 @@ mod tests {
         check(&["{", "abc", "}", "{"], &["{", "123", "}"]);
         check(&["{", "abc", "}"], &["{", "123", "}", "{"]);
         check(&["{", "abc", "}ab"], &["{", "abc", "}", "ab"]);
+    }
+
+    #[allow(dead_code)]
+    mod impl_asserts {
+        use super::*;
+
+        struct NotClone;
+
+        fn assert_copy<C: Copy>() {}
+
+        fn test_impls_copy() {
+            assert_copy::<SyntaxText<TokenInterner, SyntaxKind, NotClone>>();
+        }
     }
 }


### PR DESCRIPTION
Previously, we couldn't clone `SyntaxNodeChildren<S, D>` if D wasn't `Clone`, but `D` doesn't get cloned, so this is misleading and overly restrictive.

This patch fixes that & other structs that did the same thing.