### PR TITLE
text: add SyntaxText::rfind_char

### DIFF
--- a/cstree/src/syntax/text.rs
+++ b/cstree/src/syntax/text.rs
@@ -91,6 +91,18 @@ impl<'n, 'i, I: Resolver<TokenKey> + ?Sized, S: Syntax, D> SyntaxText<'n, 'i, I,
         found(res)
     }
 
+    /// If `self.contains_char(c)`, returns `Some(pos)`, where `pos` is the byte position of the
+    /// last appearance of `c`. Otherwise, returns `None`.
+    pub fn rfind_char(&self, c: char) -> Option<TextSize> {
+        let mut acc: TextSize = 0.into();
+        let mut res = None;
+        self.for_each_chunk(|chunk| {
+            res = chunk.rfind(c).map(|pos| acc + TextSize::from(pos as u32)).or(res);
+            acc += TextSize::of(chunk);
+        });
+        res
+    }
+
     /// If `offset < self.len()`, returns `Some(c)`, where `c` is the first `char` at or after
     /// `offset` (in bytes). Otherwise, returns `None`.
     pub fn char_at(&self, offset: TextSize) -> Option<char> {


### PR DESCRIPTION
In use:

```rs
   fn span_last_line(self) -> Span {
      match self {
         SegmentRawRef::Content(content) => {
            match content.text().rfind('\n') {
               Some(len) => {
                  Span::at_end(
                     content.span().end,
                     content.text().len() - len - '\n'.len_utf8(),
                  )
               },
               None => content.span(),
            }
         },

         SegmentRawRef::Interpolation(interpolation) => {
            match interpolation.text().rfind_char('\n') { // !!
               Some(len) => {
                  Span::at_end(
                     interpolation.span().end,
                     interpolation.text().size() - len - '\n'.len_utf8(),
                  )
               },
               None => interpolation.span(),
            }
         },
      }
   }
```

<img width="428" height="286" alt="image" src="https://github.com/user-attachments/assets/157b9365-eb0e-4466-9584-ee3cab06d156" />
