### PR TITLE
Don't overly restrict lifetimes of syntax tree iterators

### DIFF
--- a/cstree/src/syntax/element.rs
+++ b/cstree/src/syntax/element.rs
@@ -292,7 +292,7 @@ impl<'a, S: Syntax, D> SyntaxElementRef<'a, S, D> {
 
     /// Returns an iterator along the chain of parents of this node.
     #[inline]
-    pub fn ancestors(&self) -> impl Iterator<Item = &'a SyntaxNode<S, D>> {
+    pub fn ancestors(&self) -> impl Iterator<Item = &'a SyntaxNode<S, D>> + use<'a, S, D> {
         match self {
             NodeOrToken::Node(it) => it.ancestors(),
             NodeOrToken::Token(it) => it.parent().ancestors(),

--- a/cstree/src/syntax/resolved.rs
+++ b/cstree/src/syntax/resolved.rs
@@ -713,7 +713,7 @@ impl<'a, S: Syntax, D> ResolvedElementRef<'a, S, D> {
 
     /// Returns an iterator along the chain of parents of this node.
     #[inline]
-    pub fn ancestors(&self) -> impl Iterator<Item = &'a ResolvedNode<S, D>> {
+    pub fn ancestors(&self) -> impl Iterator<Item = &'a ResolvedNode<S, D>> + use<'a, S, D> {
         match self {
             NodeOrToken::Node(it) => it.ancestors(),
             NodeOrToken::Token(it) => it.parent().ancestors(),

--- a/cstree/src/syntax/text.rs
+++ b/cstree/src/syntax/text.rs
@@ -150,7 +150,7 @@ impl<'n, 'i, I: Resolver<TokenKey> + ?Sized, S: Syntax, D> SyntaxText<'n, 'i, I,
     /// See also [`fold_chunks`](SyntaxText::fold_chunks) for folds that always succeed.
     pub fn try_fold_chunks<T, F, E>(&self, init: T, mut f: F) -> Result<T, E>
     where
-        F: FnMut(T, &str) -> Result<T, E>,
+        F: FnMut(T, &'i str) -> Result<T, E>,
     {
         self.tokens_with_ranges().try_fold(init, move |acc, (token, range)| {
             f(acc, &token.resolve_text(self.resolver)[range])
@@ -195,7 +195,7 @@ impl<'n, 'i, I: Resolver<TokenKey> + ?Sized, S: Syntax, D> SyntaxText<'n, 'i, I,
         self.fold_chunks((), |(), chunk| f(chunk))
     }
 
-    fn tokens_with_ranges(&self) -> impl Iterator<Item = (&SyntaxToken<S, D>, TextRange)> {
+    fn tokens_with_ranges(&self) -> impl Iterator<Item = (&'n SyntaxToken<S, D>, TextRange)> + use<'i, 'n, I, S, D> {
         let text_range = self.range;
         self.node
             .descendants_with_tokens()


### PR DESCRIPTION
don't overrestrict lifetimes, prefer `use<...>` to prevent `impl Trait` from capturing too much