### PR TITLE
Chore: Edition and Dependency Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
  * `&I` and `&mut I` will now implement `Resolver` if `I` implements `Resolver`.
  * `&mut I` will now implement `Interner` if `I` implements `Interner`.
  * Added an implementation for `Arc<MultiThreadedTokenInterner>` to implement `Resolver` and `Interner` so an `Arc` may be used alternatively to a reference to share access to the interner.
+ * `SyntaxText` and the `SyntaxNodeChildren` iterator now correctly implement `Clone` independently of the generic syntax node data type `D`.
+ * The iterators returned by the `ancestors` methods on `SyntaxElementRef` / `ResolvedElementRef` no longer incorrectly capture the lifetime of the original syntax node (`self`).
+ * `cstree` was migrated to Rust edition 2024. This increases MSRV to Rust 1.85.
 
 ## `v0.12.2`
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-edition = "2021"
+edition = "2024"
 version = "0.12.2" # when updating, also update `#![doc(html_root_url)]` and any inter-crate dependencies (such as `cstree`'s dependency on `cstree-derive`)
 authors = [
     "Domenic Quirl <DomenicQuirl@pm.me>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ authors = [
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/domenicquirl/cstree"
 readme = "README.md"
-rust-version = "1.84"
+rust-version = "1.85"
 
 [profile.release]
 debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-version = "0.12.2" # when updating, also update `#![doc(html_root_url)]` and any inter-crate dependencies (such as `cstree`'s dependency on `cstree-derive`)
+version = "0.13.0" # when updating, also update `#![doc(html_root_url)]` and any inter-crate dependencies (such as `cstree`'s dependency on `cstree-derive`)
 authors = [
     "Domenic Quirl <DomenicQuirl@pm.me>",
     "Aleksey Kladov <aleksey.kladov@gmail.com>",

--- a/cstree-derive/Cargo.toml
+++ b/cstree-derive/Cargo.toml
@@ -15,9 +15,9 @@ name       = "cstree_derive"
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0.56"
-quote       = "1.0.26"
-syn         = { version = "2.0.14" }
+proc-macro2 = "1.0.95"
+quote       = "1.0.40"
+syn         = { version = "2.0.104" }
 
 [dev-dependencies]
 cstree = { path = "../cstree" }

--- a/cstree-derive/src/lib.rs
+++ b/cstree-derive/src/lib.rs
@@ -17,7 +17,7 @@ use errors::ErrorContext;
 use parsing::SyntaxKindEnum;
 use proc_macro2::TokenStream;
 use quote::{quote, quote_spanned};
-use syn::{parse_macro_input, spanned::Spanned, DeriveInput};
+use syn::{DeriveInput, parse_macro_input, spanned::Spanned};
 
 mod errors;
 mod parsing;

--- a/cstree-derive/src/parsing.rs
+++ b/cstree-derive/src/parsing.rs
@@ -1,6 +1,6 @@
 mod attributes;
 
-use syn::{punctuated::Punctuated, Token};
+use syn::{Token, punctuated::Punctuated};
 
 use crate::{errors::ErrorContext, symbols::*};
 

--- a/cstree/Cargo.toml
+++ b/cstree/Cargo.toml
@@ -12,15 +12,15 @@ readme.workspace       = true
 rust-version.workspace = true
 
 [dependencies]
-text-size   = "1.1.0"
+text-size   = "1.1.1"
 rustc-hash  = "2.1.1"
-parking_lot = "0.12.1"
+parking_lot = "0.12.4"
 
 # Arc
-triomphe = { version = "0.1.8", default-features = false, features = ["stable_deref_trait", "std"] }
+triomphe = { version = "0.1.14", default-features = false, features = ["stable_deref_trait", "std"] }
 
 # Default Interner
-indexmap = "2.4.0"
+indexmap = "2.10.0"
 
 [dependencies.cstree_derive]
 path     = "../cstree-derive"
@@ -28,7 +28,7 @@ version  = "0.12.2"           # must match the `cstree` version in the virtual w
 optional = true
 
 [dependencies.lasso]
-version  = "0.7"
+version  = "0.7.3"
 features = ["inline-more"]
 optional = true
 
@@ -48,7 +48,7 @@ features         = ["derive", "std"]
 m_lexer         = "0.0.4"
 serde_json      = "1.0"
 serde_test      = "1.0"
-crossbeam-utils = "0.8"
+crossbeam-utils = "0.8.21"
 criterion       = { version = "0.5.1", features = ["html_reports"] }
 
 [[bench]]

--- a/cstree/Cargo.toml
+++ b/cstree/Cargo.toml
@@ -24,7 +24,7 @@ indexmap = "2.10.0"
 
 [dependencies.cstree_derive]
 path     = "../cstree-derive"
-version  = "0.12.2"           # must match the `cstree` version in the virtual workspace manifest
+version  = "0.13.0"           # must match the `cstree` version in the virtual workspace manifest
 optional = true
 
 [dependencies.lasso]

--- a/cstree/Cargo.toml
+++ b/cstree/Cargo.toml
@@ -49,7 +49,7 @@ m_lexer         = "0.0.4"
 serde_json      = "1.0"
 serde_test      = "1.0"
 crossbeam-utils = "0.8.21"
-criterion       = { version = "0.5.1", features = ["html_reports"] }
+criterion       = { version = "0.7.0", features = ["html_reports"] }
 
 [[bench]]
 name    = "main"

--- a/cstree/benches/main.rs
+++ b/cstree/benches/main.rs
@@ -1,4 +1,6 @@
-use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
+use core::hint::black_box;
+
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
 use cstree::{
     RawSyntaxKind,
     Syntax,

--- a/cstree/benches/main.rs
+++ b/cstree/benches/main.rs
@@ -1,9 +1,10 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
 use cstree::{
+    RawSyntaxKind,
+    Syntax,
     build::*,
     green::GreenNode,
-    interning::{new_interner, Interner},
-    RawSyntaxKind, Syntax,
+    interning::{Interner, new_interner},
 };
 
 #[derive(Debug)]

--- a/cstree/examples/math.rs
+++ b/cstree/examples/math.rs
@@ -13,7 +13,7 @@
 //!     - "+" Token(Add)
 //!     - "4" Token(Number)
 
-use cstree::{build::GreenNodeBuilder, interning::Resolver, util::NodeOrToken, Syntax};
+use cstree::{Syntax, build::GreenNodeBuilder, interning::Resolver, util::NodeOrToken};
 use std::iter::Peekable;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Syntax)]
@@ -99,7 +99,7 @@ impl<'input, I: Iterator<Item = (SyntaxKind, &'input str)>> Parser<'input, I> {
         self.handle_operation(&[Add, Sub], Self::parse_mul)
     }
 
-    fn parse(mut self) -> (SyntaxNode, impl Resolver) {
+    fn parse(mut self) -> (SyntaxNode, impl Resolver + use<I>) {
         self.builder.start_node(Root);
         self.parse_add();
         self.builder.finish_node();

--- a/cstree/examples/readme.rs
+++ b/cstree/examples/readme.rs
@@ -208,7 +208,7 @@ impl<'input> Parser<'input> {
         Ok(())
     }
 
-    pub fn finish(mut self) -> (GreenNode, impl Interner) {
+    pub fn finish(mut self) -> (GreenNode, impl Interner + use<>) {
         assert!(self.lexer.next().map(|t| t == Token::EoF).unwrap_or(true));
         let (tree, cache) = self.builder.finish();
         (tree, cache.unwrap().into_interner().unwrap())

--- a/cstree/examples/s_expressions.rs
+++ b/cstree/examples/s_expressions.rs
@@ -62,7 +62,7 @@ struct Parse<I> {
 /// Now, let's write a parser.
 /// Note that `parse` does not return a `Result`:
 /// By design, syntax trees can be built even for completely invalid source code.
-fn parse(text: &str) -> Parse<impl Resolver> {
+fn parse(text: &str) -> Parse<impl Resolver + use<>> {
     struct Parser<'input> {
         /// input tokens, including whitespace.
         tokens:  VecDeque<(SyntaxKind, &'input str)>,
@@ -83,7 +83,7 @@ fn parse(text: &str) -> Parse<impl Resolver> {
     }
 
     impl Parser<'_> {
-        fn parse(mut self) -> Parse<impl Resolver> {
+        fn parse(mut self) -> Parse<impl Resolver + use<>> {
             // Make sure that the root node covers all source
             self.builder.start_node(Root);
             // Parse zero or more S-expressions

--- a/cstree/src/green/builder.rs
+++ b/cstree/src/green/builder.rs
@@ -4,11 +4,12 @@ use rustc_hash::{FxHashMap, FxHasher};
 use text_size::TextSize;
 
 use crate::{
+    RawSyntaxKind,
+    Syntax,
     green::{GreenElement, GreenNode, GreenToken},
-    interning::{new_interner, Interner, TokenInterner, TokenKey},
+    interning::{Interner, TokenInterner, TokenKey, new_interner},
     util::NodeOrToken,
     utility_types::MaybeOwned,
-    RawSyntaxKind, Syntax,
 };
 
 use super::{node::GreenNodeHead, token::GreenTokenData};

--- a/cstree/src/green/element.rs
+++ b/cstree/src/green/element.rs
@@ -5,10 +5,10 @@ use std::{fmt, hash, mem};
 type ErasedPtr = *const u8;
 
 use crate::{
+    RawSyntaxKind,
     green::{GreenNode, GreenToken},
     text::TextSize,
     util::NodeOrToken,
-    RawSyntaxKind,
 };
 
 pub(super) type GreenElement = NodeOrToken<GreenNode, GreenToken>;

--- a/cstree/src/green/iter.rs
+++ b/cstree/src/green/iter.rs
@@ -2,7 +2,7 @@
 
 use std::{iter::FusedIterator, slice};
 
-use super::{element::PackedGreenElement, GreenElementRef};
+use super::{GreenElementRef, element::PackedGreenElement};
 
 /// An iterator over a [`GreenNode`](crate::green::GreenNode)'s children.
 #[derive(Debug, Clone)]

--- a/cstree/src/green/node.rs
+++ b/cstree/src/green/node.rs
@@ -6,9 +6,9 @@ use std::{
 use rustc_hash::FxHasher;
 
 use crate::{
-    green::{iter::GreenNodeChildren, GreenElement, PackedGreenElement},
-    text::TextSize,
     RawSyntaxKind,
+    green::{GreenElement, PackedGreenElement, iter::GreenNodeChildren},
+    text::TextSize,
 };
 use triomphe::{Arc, HeaderWithLength, ThinArc};
 

--- a/cstree/src/green/token.rs
+++ b/cstree/src/green/token.rs
@@ -1,9 +1,9 @@
 use std::{fmt, hash, mem::ManuallyDrop, ptr::NonNull};
 
 use crate::{
+    RawSyntaxKind,
     interning::{Resolver, TokenKey},
     text::TextSize,
-    RawSyntaxKind,
 };
 use triomphe::Arc;
 

--- a/cstree/src/interning/lasso_compat/traits.rs
+++ b/cstree/src/interning/lasso_compat/traits.rs
@@ -4,8 +4,8 @@ use core::fmt;
 use std::hash::{BuildHasher, Hash};
 
 use crate::interning::{
-    traits::{InternKey, Interner, Resolver},
     TokenKey,
+    traits::{InternKey, Interner, Resolver},
 };
 
 // Safety: `InternKey` has the same invariant as `lasso::Key`

--- a/cstree/src/lib.rs
+++ b/cstree/src/lib.rs
@@ -93,7 +93,7 @@
 )]
 #![warn(missing_docs)]
 // Docs.rs
-#![doc(html_root_url = "https://docs.rs/cstree/0.12.2")]
+#![doc(html_root_url = "https://docs.rs/cstree/0.13.0")]
 #![cfg_attr(doc_cfg, feature(doc_cfg))]
 
 pub mod getting_started;

--- a/cstree/src/lib.rs
+++ b/cstree/src/lib.rs
@@ -135,10 +135,11 @@ pub mod build {
 /// A convenient collection of the most used parts of `cstree`.
 pub mod prelude {
     pub use crate::{
+        RawSyntaxKind,
+        Syntax,
         build::GreenNodeBuilder,
         green::{GreenNode, GreenToken},
         syntax::{SyntaxElement, SyntaxNode, SyntaxToken},
-        RawSyntaxKind, Syntax,
     };
 }
 

--- a/cstree/src/serde_impls.rs
+++ b/cstree/src/serde_impls.rs
@@ -1,17 +1,19 @@
 //! Serialization and Deserialization for syntax trees.
 
 use crate::{
+    RawSyntaxKind,
+    Syntax,
     build::GreenNodeBuilder,
     interning::{Resolver, TokenKey},
     syntax::{ResolvedNode, SyntaxNode},
     traversal::WalkEvent,
     util::NodeOrToken,
-    RawSyntaxKind, Syntax,
 };
 use serde::{
+    Deserialize,
+    Serialize,
     de::{Error, SeqAccess, Visitor},
     ser::SerializeTuple,
-    Deserialize, Serialize,
 };
 use std::{collections::VecDeque, fmt, marker::PhantomData};
 

--- a/cstree/src/syntax/element.rs
+++ b/cstree/src/syntax/element.rs
@@ -4,10 +4,11 @@ use text_size::{TextRange, TextSize};
 
 use super::*;
 use crate::{
+    RawSyntaxKind,
+    Syntax,
     green::GreenElementRef,
     interning::{Resolver, TokenKey},
     util::{NodeOrToken, TokenAtOffset},
-    RawSyntaxKind, Syntax,
 };
 
 /// An element of the tree, can be either a node or a token.

--- a/cstree/src/syntax/iter.rs
+++ b/cstree/src/syntax/iter.rs
@@ -5,9 +5,9 @@ use std::iter::FusedIterator;
 use text_size::TextSize;
 
 use crate::{
+    Syntax,
     green::{GreenElementRef, GreenNodeChildren},
     syntax::{SyntaxElementRef, SyntaxNode},
-    Syntax,
 };
 
 #[derive(Clone, Debug)]

--- a/cstree/src/syntax/node.rs
+++ b/cstree/src/syntax/node.rs
@@ -2,12 +2,13 @@ use super::*;
 #[cfg(feature = "serialize")]
 use crate::serde_impls::{SerializeWithData, SerializeWithResolver};
 use crate::{
+    RawSyntaxKind,
+    Syntax,
     green::{GreenElementRef, GreenNode},
     interning::{Resolver, TokenKey},
     text::*,
     traversal::*,
     util::*,
-    RawSyntaxKind, Syntax,
 };
 use parking_lot::RwLock;
 use std::{
@@ -17,8 +18,8 @@ use std::{
     iter,
     ptr::{self, NonNull},
     sync::{
-        atomic::{AtomicU32, Ordering},
         Arc as StdArc,
+        atomic::{AtomicU32, Ordering},
     },
 };
 use triomphe::Arc;

--- a/cstree/src/syntax/resolved.rs
+++ b/cstree/src/syntax/resolved.rs
@@ -13,12 +13,13 @@ use std::{
 use text_size::{TextRange, TextSize};
 
 use crate::{
+    RawSyntaxKind,
+    Syntax,
     green::GreenNode,
     interning::{Resolver, TokenKey},
     syntax::*,
     traversal::*,
     util::*,
-    RawSyntaxKind, Syntax,
 };
 
 /// Syntax tree node that is guaranteed to belong to a tree that contains an associated
@@ -35,7 +36,7 @@ impl<S: Syntax, D> ResolvedNode<S, D> {
     /// # Safety:
     /// `syntax` must belong to a tree that contains an associated inline resolver.
     pub(super) unsafe fn coerce_ref(syntax: &SyntaxNode<S, D>) -> &Self {
-        &*(syntax as *const _ as *const Self)
+        unsafe { &*(syntax as *const _ as *const Self) }
     }
 
     /// Returns this node as a [`SyntaxNode`].
@@ -91,7 +92,7 @@ impl<S: Syntax, D> ResolvedToken<S, D> {
     /// # Safety:
     /// `syntax` must belong to a tree that contains an associated inline resolver.
     pub(super) unsafe fn coerce_ref(syntax: &SyntaxToken<S, D>) -> &Self {
-        &*(syntax as *const _ as *const Self)
+        unsafe { &*(syntax as *const _ as *const Self) }
     }
 
     /// Returns this token as a [`SyntaxToken`].
@@ -172,9 +173,11 @@ impl<'a, S: Syntax, D> ResolvedElementRef<'a, S, D> {
     /// # Safety:
     /// `syntax` must belong to a tree that contains an associated inline resolver.
     pub(super) unsafe fn coerce_ref(syntax: SyntaxElementRef<'a, S, D>) -> Self {
-        match syntax {
-            NodeOrToken::Node(node) => Self::Node(ResolvedNode::coerce_ref(node)),
-            NodeOrToken::Token(token) => Self::Token(ResolvedToken::coerce_ref(token)),
+        unsafe {
+            match syntax {
+                NodeOrToken::Node(node) => Self::Node(ResolvedNode::coerce_ref(node)),
+                NodeOrToken::Token(token) => Self::Token(ResolvedToken::coerce_ref(token)),
+            }
         }
     }
 }

--- a/cstree/src/syntax/text.rs
+++ b/cstree/src/syntax/text.rs
@@ -3,10 +3,10 @@
 use std::fmt;
 
 use crate::{
+    Syntax,
     interning::{Resolver, TokenKey},
     syntax::{SyntaxNode, SyntaxToken},
     text::{TextRange, TextSize},
-    Syntax,
 };
 
 /// An efficient representation of the text that is covered by a [`SyntaxNode`], i.e. the combined
@@ -383,7 +383,7 @@ mod private {
 
 #[cfg(test)]
 mod tests {
-    use crate::{build::GreenNodeBuilder, interning::TokenInterner, RawSyntaxKind};
+    use crate::{RawSyntaxKind, build::GreenNodeBuilder, interning::TokenInterner};
 
     use super::*;
 
@@ -409,7 +409,7 @@ mod tests {
         }
     }
 
-    fn build_tree(chunks: &[&str]) -> (SyntaxNode<SyntaxKind, ()>, impl Resolver<TokenKey>) {
+    fn build_tree(chunks: &[&str]) -> (SyntaxNode<SyntaxKind, ()>, impl Resolver<TokenKey> + use<>) {
         let mut builder: GreenNodeBuilder<SyntaxKind> = GreenNodeBuilder::new();
         builder.start_node(SyntaxKind(62));
         for &chunk in chunks.iter() {

--- a/cstree/src/syntax/token.rs
+++ b/cstree/src/syntax/token.rs
@@ -9,10 +9,11 @@ use text_size::{TextRange, TextSize};
 
 use super::*;
 use crate::{
+    RawSyntaxKind,
+    Syntax,
     green::{GreenNode, GreenToken},
     interning::{Resolver, TokenKey},
     traversal::Direction,
-    RawSyntaxKind, Syntax,
 };
 
 /// Syntax tree token.
@@ -284,7 +285,7 @@ impl<S: Syntax, D> SyntaxToken<S, D> {
     /// implementation by re-using the interner in both.
     /// ```
     /// # use cstree::testing::*;
-    /// use cstree::interning::{new_interner, TokenInterner, TokenKey};
+    /// use cstree::interning::{TokenInterner, TokenKey, new_interner};
     /// struct TypeTable {
     ///     // ...
     /// }

--- a/cstree/tests/it/basic.rs
+++ b/cstree/tests/it/basic.rs
@@ -1,12 +1,12 @@
 use super::*;
 use cstree::{
-    build::{GreenNodeBuilder, NodeCache},
-    interning::{new_interner, Resolver},
-    text::TextRange,
     RawSyntaxKind,
+    build::{GreenNodeBuilder, NodeCache},
+    interning::{Resolver, new_interner},
+    text::TextRange,
 };
 
-fn build_tree<D>(root: &Element<'_>) -> (SyntaxNode<D>, impl Resolver) {
+fn build_tree<D>(root: &Element<'_>) -> (SyntaxNode<D>, impl Resolver + use<D>) {
     let mut builder: GreenNodeBuilder<SyntaxKind> = GreenNodeBuilder::new();
     build_recursive(root, &mut builder, 0);
     let (node, cache) = builder.finish();

--- a/cstree/tests/it/main.rs
+++ b/cstree/tests/it/main.rs
@@ -6,11 +6,12 @@ mod sendsync;
 mod serde;
 
 use cstree::{
+    RawSyntaxKind,
+    Syntax,
     build::{GreenNodeBuilder, NodeCache},
     green::GreenNode,
     interning::{Interner, Resolver},
     util::NodeOrToken,
-    RawSyntaxKind, Syntax,
 };
 
 pub type SyntaxNode<D = ()> = cstree::syntax::SyntaxNode<SyntaxKind, D>;

--- a/cstree/tests/it/sendsync.rs
+++ b/cstree/tests/it/sendsync.rs
@@ -3,13 +3,13 @@
 use crossbeam_utils::thread::scope;
 use std::{thread, time::Duration};
 
-use super::{build_recursive, Element, ResolvedNode, SyntaxKind, SyntaxNode};
+use super::{Element, ResolvedNode, SyntaxKind, SyntaxNode, build_recursive};
 use cstree::build::GreenNodeBuilder;
 
 // Excercise the multi-threaded interner when the corresponding feature is enabled.
 
 #[cfg(feature = "multi_threaded_interning")]
-use cstree::interning::{new_threaded_interner, MultiThreadedTokenInterner};
+use cstree::interning::{MultiThreadedTokenInterner, new_threaded_interner};
 
 #[cfg(not(feature = "multi_threaded_interning"))]
 fn get_builder() -> GreenNodeBuilder<'static, 'static, SyntaxKind> {

--- a/cstree/tests/it/serde.rs
+++ b/cstree/tests/it/serde.rs
@@ -1,4 +1,4 @@
-use crate::{build_recursive, build_tree_with_cache, ResolvedNode};
+use crate::{ResolvedNode, build_recursive, build_tree_with_cache};
 
 use super::{Element, SyntaxKind, SyntaxNode};
 use cstree::{

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,6 +1,6 @@
 unstable_features = true
 
-edition = "2021"
+edition = "2024"
 
 max_width     = 120
 comment_width = 120
@@ -10,6 +10,7 @@ format_code_in_doc_comments = true
 format_macro_matchers       = true
 
 imports_granularity = "Crate"
+imports_layout      = "HorizontalVertical"
 
 reorder_impl_items = true
 

--- a/test_suite/Cargo.toml
+++ b/test_suite/Cargo.toml
@@ -13,4 +13,4 @@ rust-version.workspace = true
 cstree = { path = "../cstree", features = ["derive"] }
 
 [dev-dependencies]
-trybuild = { version = "1.0.80", features = ["diff"] }
+trybuild = { version = "1.0.106", features = ["diff"] }


### PR DESCRIPTION
* Migrates the crate to Edition 2024
  * MSRV increased from 1.84 to 1.85
* Bumps dependency versions (mostly minor, except `criterion`, which goes from 0.5 to 0.7)
* Pre-emptively bumps the crate version to 0.13.0 (from current 0.12.2)
* Updates our Changelog with the latest PRs (plus the edition update)