### PR TITLE
build: prepare release of version 0.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## `v0.14.0`
 
  * `cstree` now supports `no_std` by adding the dependency with `default-features = false`, which disables the newly introduced `std` feature (enabled by default).
+ * Added a section documenting the cargo feature flags supported by `cstree` and their effects to the `rustdoc` crate page and README.
 
 ## `v0.13.0`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## `v0.14.0`
+
+ * `cstree` now supports `no_std` by adding the dependency with `default-features = false`, which disables the newly introduced `std` feature (enabled by default).
+
 ## `v0.13.0`
 
  * `&I` and `&mut I` will now implement `Resolver` if `I` implements `Resolver`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
  * `cstree` now supports `no_std` by adding the dependency with `default-features = false`, which disables the newly introduced `std` feature (enabled by default).
  * Added a section documenting the cargo feature flags supported by `cstree` and their effects to the `rustdoc` crate page and README.
+ * Starting with this version, a `Cargo.lock` lockfile has been committed to the repository to consistently track a stable configuration of dependencies.
 
 ## `v0.13.0`
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,7 +210,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "cstree"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "criterion",
  "crossbeam-utils",
@@ -230,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "cstree_derive"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "cstree",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-version = "0.13.0" # when updating, also update `#![doc(html_root_url)]` and any inter-crate dependencies (such as `cstree`'s dependency on `cstree-derive`)
+version = "0.14.0" # when updating, also update `#![doc(html_root_url)]` and any inter-crate dependencies (such as `cstree`'s dependency on `cstree-derive`)
 authors = [
     "Domenic Quirl <DomenicQuirl@pm.me>",
     "Aleksey Kladov <aleksey.kladov@gmail.com>",

--- a/README.md
+++ b/README.md
@@ -57,7 +57,21 @@ Notable differences of `cstree` compared to `rowan`:
   still `clone` the reference to obtain an owned node, but you only pay that cost when you need to.
 - The downside of offering thread safe syntax trees is that `cstree` cannot offer any mutability API for its CSTs.
   Trees can still be updated into new trees through replacing nodes, but cannot be mutated in place.
-- `cstree` is also fully compatible with #[no_std] by disabling the std feature and including a global allocator with the alloc crate. However, disabling the `std` feature disables some optimizations that are not possible in no_std contexts.
+- `cstree` is also fully compatible with #[no_std] by disabling the std feature and including a global allocator with the alloc crate. 
+  However, disabling the `std` feature disables some optimizations that are not possible in no_std contexts.
+
+## Cargo Feature Flags
+
+`cstree` contains several optional features that extend the crate’s functionality.
+
+- `std` (enabled by default) - Support for standard library features
+- `derive` - Adds support for deriving the `Syntax` trait
+- `serialize` - Implements `serde::{De,}Serialize` for CSTs
+- `lasso` - Allows using interners from the `lasso` crate for green trees. 
+  - When enabled, `cstree`'s default interners will use `lasso` internally, too.
+- `multi_threaded_interning` - Additionally provide threadsafe interner types. 
+  - Where applicable (and if the corresponding features are selected), enabling this feature will also make `cstree` provide compatibility implementations for multi-threaded interners from other crates.
+  - Enabling this feature will automatically enable the `lasso` feature, as the multi-threaded interners are backed by `lasso`.
 
 ## Getting Started
 

--- a/cstree/Cargo.toml
+++ b/cstree/Cargo.toml
@@ -27,7 +27,7 @@ indexmap = { version = "2.10.0", default-features = false }
 
 [dependencies.cstree_derive]
 path     = "../cstree-derive"
-version  = "0.13.0"           # must match the `cstree` version in the virtual workspace manifest
+version  = "0.14.0"           # must match the `cstree` version in the virtual workspace manifest
 optional = true
 
 [dependencies.lasso]

--- a/cstree/src/lib.rs
+++ b/cstree/src/lib.rs
@@ -52,6 +52,21 @@
 //!
 //! [replacing]: syntax::SyntaxNode::replace_with
 //!
+//! ## Cargo Feature Flags
+//!
+//! `cstree` contains several optional features that extend the crate’s functionality.
+//!
+//! - `std` (enabled by default) - Support for standard library features
+//! - `derive` - Adds support for deriving the `Syntax` trait
+//! - `serialize` - Implements `serde::{De,}Serialize` for CSTs
+//! - `lasso` - Allows using interners from the `lasso` crate for green trees.
+//!   - When enabled, `cstree`'s default interners will use `lasso` internally, too.
+//! - `multi_threaded_interning` - Additionally provide threadsafe interner types.
+//!   - Where applicable (and if the corresponding features are selected), enabling this feature will also make `cstree`
+//!     provide compatibility implementations for multi-threaded interners from other crates.
+//!   - Enabling this feature will automatically enable the `lasso` feature, as the multi-threaded interners are backed
+//!     by `lasso`.
+//!
 //! ## Getting Started
 //! If you're looking at `cstree`, you're probably looking at or already writing a parser and are considering using
 //! concrete syntax trees as its output. We'll talk more about parsing below -- first, let's have a look at what needs

--- a/cstree/src/lib.rs
+++ b/cstree/src/lib.rs
@@ -94,7 +94,7 @@
 )]
 #![warn(missing_docs)]
 // Docs.rs
-#![doc(html_root_url = "https://docs.rs/cstree/0.13.0")]
+#![doc(html_root_url = "https://docs.rs/cstree/0.14.0")]
 #![cfg_attr(doc_cfg, feature(doc_cfg))]
 
 #[cfg(feature = "derive")]


### PR DESCRIPTION
Bumps the crate version and adjusts the changelog.