### PR TITLE
build: set 'default-members' in workspace manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,10 @@ members = [
     "cstree-derive",
     "test_suite",
 ]
+default-members = [
+    "cstree",
+    "cstree-derive",
+]
 resolver = "2"
 
 [workspace.package]


### PR DESCRIPTION
This excludes our `test_suite` from being considered a regular package for commands like `cargo publish`.