### PR TITLE
ci: add trusted publishing workflow for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,17 @@
+name: Publish to crates.io
+on:
+  push:
+    tags: ['v*']  # Triggers when pushing tags starting with 'v'
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: crates-io
+    permissions:
+      id-token: write     # Required for OIDC token exchange
+    steps:
+    - uses: actions/checkout@v6
+    - uses: rust-lang/crates-io-auth-action@v1
+      id: auth
+    - run: cargo publish
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
The workflow runs on new version tags and is allowed to publish to crates.io once trusted publishing has been configured for it in the registry settings. The publish will then be verified on crates.io to have come from this repository, which allows publishing through a short-lived token that does not need to be manually created and stored as a longer-lived repository secret.

For further information, see <https://crates.io/docs/trusted-publishing>. Note that we will need to configure this workflow as a trusted publisher for both `cstree` and `cstree-derive`, as the configuration is per-crate on crates.io.